### PR TITLE
feat: Add category endpoints findById and findAll logic

### DIFF
--- a/src/main/java/fun/trackmoney/category/controller/CategoryController.java
+++ b/src/main/java/fun/trackmoney/category/controller/CategoryController.java
@@ -1,0 +1,33 @@
+package fun.trackmoney.category.controller;
+
+import fun.trackmoney.category.entity.CategoryEntity;
+import fun.trackmoney.category.service.CategoryService;
+import fun.trackmoney.utils.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("category")
+public class CategoryController {
+
+  private final CategoryService categoryService;
+
+  public CategoryController(CategoryService categoryService) {
+    this.categoryService = categoryService;
+  }
+
+  @GetMapping("/findAll")
+  public ResponseEntity<ApiResponse<List<CategoryEntity>>> findAll() {
+    return ResponseEntity.ok().body(new ApiResponse<>(true, "Category", categoryService.findAll(), null));
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<ApiResponse<CategoryEntity>> findById(@PathVariable Integer id) {
+    return ResponseEntity.ok().body(new ApiResponse<>(true, "Category", categoryService.findById(id), null));
+  }
+}

--- a/src/main/java/fun/trackmoney/category/exception/CategoryNotFoundException.java
+++ b/src/main/java/fun/trackmoney/category/exception/CategoryNotFoundException.java
@@ -1,0 +1,7 @@
+package fun.trackmoney.category.exception;
+
+public class CategoryNotFoundException extends RuntimeException {
+  public CategoryNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/fun/trackmoney/category/repository/CategoryRepository.java
+++ b/src/main/java/fun/trackmoney/category/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package fun.trackmoney.category.repository;
+
+import fun.trackmoney.category.entity.CategoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<CategoryEntity, Integer> {
+}

--- a/src/main/java/fun/trackmoney/category/service/CategoryService.java
+++ b/src/main/java/fun/trackmoney/category/service/CategoryService.java
@@ -1,0 +1,29 @@
+package fun.trackmoney.category.service;
+
+import fun.trackmoney.category.entity.CategoryEntity;
+import fun.trackmoney.category.exception.CategoryNotFoundException;
+import fun.trackmoney.category.repository.CategoryRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CategoryService {
+
+  private final CategoryRepository categoryRepository;
+
+  public CategoryService(CategoryRepository categoryRepository) {
+    this.categoryRepository = categoryRepository;
+  }
+
+  public List<CategoryEntity> findAll() {
+    return categoryRepository.findAll();
+  }
+
+  public CategoryEntity findById(Integer categoryId) {
+    return categoryRepository.findById(categoryId)
+        .orElseThrow(() -> {
+          throw new CategoryNotFoundException("Category not found.");
+        });
+  }
+}

--- a/src/main/java/fun/trackmoney/config/exception/RestExceptionHandler.java
+++ b/src/main/java/fun/trackmoney/config/exception/RestExceptionHandler.java
@@ -1,6 +1,7 @@
 package fun.trackmoney.config.exception;
 
 import fun.trackmoney.auth.exception.LoginException;
+import fun.trackmoney.category.exception.CategoryNotFoundException;
 import fun.trackmoney.user.exception.EmailAlreadyExistsException;
 import fun.trackmoney.user.exception.EmailNotFoundException;
 import fun.trackmoney.user.exception.PasswordNotValid;
@@ -64,5 +65,13 @@ public class RestExceptionHandler {
     return ResponseEntity.badRequest().body(
         new ApiResponse<>(false, ex.getMessage(), null, ex.getErrors())
     );
+  }
+
+  @ExceptionHandler(CategoryNotFoundException.class)
+  public ResponseEntity<ApiResponse<List<CustomFieldError>>> categoryNotFound(CategoryNotFoundException ex) {
+    return ResponseEntity
+        .status(HttpStatus.NOT_FOUND)
+        .body(new ApiResponse<>(false, ex.getMessage(), null,
+            List.of(new CustomFieldError("Email", ex.getMessage()))));
   }
 }

--- a/src/main/java/fun/trackmoney/config/exception/RestExceptionHandler.java
+++ b/src/main/java/fun/trackmoney/config/exception/RestExceptionHandler.java
@@ -72,6 +72,6 @@ public class RestExceptionHandler {
     return ResponseEntity
         .status(HttpStatus.NOT_FOUND)
         .body(new ApiResponse<>(false, ex.getMessage(), null,
-            List.of(new CustomFieldError("Email", ex.getMessage()))));
+            List.of(new CustomFieldError("Category", ex.getMessage()))));
   }
 }

--- a/src/test/java/fun/trackmoney/category/controller/CategoryControllerTest.java
+++ b/src/test/java/fun/trackmoney/category/controller/CategoryControllerTest.java
@@ -1,0 +1,98 @@
+package fun.trackmoney.category.controller;
+
+import fun.trackmoney.category.entity.CategoryEntity;
+import fun.trackmoney.category.exception.CategoryNotFoundException;
+import fun.trackmoney.category.service.CategoryService;
+import fun.trackmoney.utils.response.ApiResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryControllerTest {
+
+  @Mock
+  private CategoryService categoryService;
+
+  @InjectMocks
+  private CategoryController categoryController;
+
+  @Test
+  void findAll_shouldReturnOkResponseWithCategoryList() {
+    // Arrange
+    CategoryEntity category1 = new CategoryEntity();
+    category1.setCategoryId(1);
+    category1.setName("Food");
+
+    CategoryEntity category2 = new CategoryEntity();
+    category2.setCategoryId(2);
+    category2.setName("Transportation");
+
+    List<CategoryEntity> categories = Arrays.asList(category1, category2);
+    when(categoryService.findAll()).thenReturn(categories);
+
+    // Act
+    ResponseEntity<ApiResponse<List<CategoryEntity>>> response = categoryController.findAll();
+
+    // Assert
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    ApiResponse<List<CategoryEntity>> apiResponse = response.getBody();
+    assertTrue(apiResponse.isSuccess());
+    assertEquals("Category", apiResponse.getMessage());
+    assertEquals(categories.size(), apiResponse.getData().size());
+    assertTrue(apiResponse.getData().containsAll(categories));
+    assertEquals(null, apiResponse.getErrors());
+  }
+
+  @Test
+  void findById_shouldReturnOkResponseWithCategory_whenIdExists() {
+    // Arrange
+    Integer categoryId = 1;
+    CategoryEntity category = new CategoryEntity();
+    category.setCategoryId(categoryId);
+    category.setName("Food");
+
+    when(categoryService.findById(categoryId)).thenReturn(category);
+
+    // Act
+    ResponseEntity<ApiResponse<CategoryEntity>> response = categoryController.findById(categoryId);
+
+    // Assert
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    ApiResponse<CategoryEntity> apiResponse = response.getBody();
+    assertTrue(apiResponse.isSuccess());
+    assertEquals("Category", apiResponse.getMessage());
+    assertEquals(category.getCategoryId(), apiResponse.getData().getCategoryId());
+    assertEquals(category.getName(), apiResponse.getData().getName());
+    assertEquals(null, apiResponse.getErrors());
+  }
+
+  @Test
+  void findById_shouldReturnNotFound_whenCategoryNotFound() {
+    // Arrange
+    Integer categoryId = 99;
+    when(categoryService.findById(categoryId)).thenThrow(new CategoryNotFoundException("Category not found."));
+
+    // Act
+    try {
+      categoryController.findById(categoryId);
+    } catch (CategoryNotFoundException e) {
+      // Assert that the exception is thrown.
+      assertEquals("Category not found.", e.getMessage());
+      return;
+    }
+    // Should not reach here if the exception is thrown.
+    assertTrue(false, "CategoryNotFoundException should have been thrown.");
+  }
+}

--- a/src/test/java/fun/trackmoney/category/service/CategoryServiceTest.java
+++ b/src/test/java/fun/trackmoney/category/service/CategoryServiceTest.java
@@ -1,0 +1,77 @@
+package fun.trackmoney.category.service;
+
+import fun.trackmoney.category.entity.CategoryEntity;
+import fun.trackmoney.category.exception.CategoryNotFoundException;
+import fun.trackmoney.category.repository.CategoryRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryServiceTest {
+
+  @Mock
+  private CategoryRepository categoryRepository;
+
+  @InjectMocks
+  private CategoryService categoryService;
+
+  @Test
+  void findAll_shouldReturnAllCategories() {
+    // Arrange
+    CategoryEntity category1 = new CategoryEntity();
+    category1.setCategoryId(1);
+    category1.setName("Food");
+
+    CategoryEntity category2 = new CategoryEntity();
+    category2.setCategoryId(2);
+    category2.setName("Transportation");
+
+    List<CategoryEntity> expectedCategories = Arrays.asList(category1, category2);
+    when(categoryRepository.findAll()).thenReturn(expectedCategories);
+
+    // Act
+    List<CategoryEntity> actualCategories = categoryService.findAll();
+
+    // Assert
+    assertEquals(expectedCategories.size(), actualCategories.size());
+    assertTrue(actualCategories.containsAll(expectedCategories));
+  }
+
+  @Test
+  void findById_shouldReturnCategory_whenIdExists() {
+    // Arrange
+    Integer categoryId = 1;
+    CategoryEntity expectedCategory = new CategoryEntity();
+    expectedCategory.setCategoryId(categoryId);
+    expectedCategory.setName("Food");
+
+    when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(expectedCategory));
+
+    // Act
+    CategoryEntity actualCategory = categoryService.findById(categoryId);
+
+    // Assert
+    assertEquals(expectedCategory.getCategoryId(), actualCategory.getCategoryId());
+    assertEquals(expectedCategory.getName(), actualCategory.getName());
+  }
+
+  @Test
+  void findById_shouldThrowCategoryNotFoundException_whenIdDoesNotExist() {
+    // Arrange
+    Integer categoryId = 99;
+    when(categoryRepository.findById(categoryId)).thenReturn(Optional.empty());
+
+    // Act and Assert
+    assertThrows(CategoryNotFoundException.class, () -> categoryService.findById(categoryId));
+  }
+}

--- a/src/test/java/fun/trackmoney/config/exception/RestExceptionHandlerTest.java
+++ b/src/test/java/fun/trackmoney/config/exception/RestExceptionHandlerTest.java
@@ -1,6 +1,7 @@
 package fun.trackmoney.config.exception;
 
 import fun.trackmoney.auth.exception.LoginException;
+import fun.trackmoney.category.exception.CategoryNotFoundException;
 import fun.trackmoney.user.exception.EmailAlreadyExistsException;
 import fun.trackmoney.user.exception.EmailNotFoundException;
 import fun.trackmoney.user.exception.PasswordNotValid;
@@ -134,5 +135,23 @@ class RestExceptionHandlerTest {
     assertEquals("Password is incorrect.", apiResponse.getErrors().get(0).getMessage());
     assertNotNull(apiResponse.getErrors());
     assertEquals(errors.size(), apiResponse.getErrors().size());
+  }
+
+  @Test
+  void categoryNotFound_shouldReturnNotFoundWithError() {
+    CategoryNotFoundException exception = new CategoryNotFoundException("Category with id 99 not found.");
+    ResponseEntity<ApiResponse<List<CustomFieldError>>> response = restExceptionHandler.categoryNotFound(exception);
+
+    assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    ApiResponse<List<CustomFieldError>> apiResponse = response.getBody();
+    assertNotNull(apiResponse);
+    assertFalse(apiResponse.isSuccess());
+    assertEquals("Category with id 99 not found.", apiResponse.getMessage());
+    assertNull(apiResponse.getData());
+    assertNotNull(apiResponse.getErrors());
+    assertEquals(1, (apiResponse.getErrors()).size());
+    CustomFieldError error = (CustomFieldError) ((List<?>) apiResponse.getErrors()).get(0);
+    assertEquals("Category", error.getField());
+    assertEquals("Category with id 99 not found.", error.getMessage());
   }
 }


### PR DESCRIPTION
## Pull Request Description

> This PR adds category endpoints `findById` and `findAll`.

### Related Task
> #29

### What was done?
> Added two endpoints: `findById` and `findAll`.

### Tests
- [x] I tested the new feature/fix locally.
- [x] I wrote tests.

### How to Test
> 1. Build and run the application.
> 2. Access the `findAll` endpoint (e.g., `/category/findAll`) to retrieve all categories.
> 3. Access the `findById` endpoint (e.g., `/category/{id}`, replacing `{id}` with an existing category ID) to retrieve a specific category.
> 4. Verify that the responses are as expected (list of categories for `findAll`, a single category for `findById`).

### Dependencies
> None.

### Useful Links
> None.