### PR TITLE
feat: add goals crud

### DIFF
--- a/src/main/java/fun/trackmoney/config/exception/RestExceptionHandler.java
+++ b/src/main/java/fun/trackmoney/config/exception/RestExceptionHandler.java
@@ -3,6 +3,7 @@ package fun.trackmoney.config.exception;
 import fun.trackmoney.account.exception.AccountNotFoundException;
 import fun.trackmoney.auth.exception.LoginException;
 import fun.trackmoney.category.exception.CategoryNotFoundException;
+import fun.trackmoney.goal.exception.GoalsNotFoundException;
 import fun.trackmoney.transaction.exception.TransactionNotFoundException;
 import fun.trackmoney.user.exception.EmailAlreadyExistsException;
 import fun.trackmoney.user.exception.UserNotFoundException;
@@ -87,6 +88,14 @@ public class RestExceptionHandler {
 
   @ExceptionHandler(TransactionNotFoundException.class)
   public ResponseEntity<ApiResponse<List<CustomFieldError>>> transactionNotFound(TransactionNotFoundException ex) {
+    return ResponseEntity
+        .status(HttpStatus.NOT_FOUND)
+        .body(new ApiResponse<>(false, ex.getMessage(), null, ex.getErrors())
+        );
+  }
+
+  @ExceptionHandler(GoalsNotFoundException.class)
+  public ResponseEntity<ApiResponse<List<CustomFieldError>>> goalsNotFound(GoalsNotFoundException ex) {
     return ResponseEntity
         .status(HttpStatus.NOT_FOUND)
         .body(new ApiResponse<>(false, ex.getMessage(), null, ex.getErrors())

--- a/src/main/java/fun/trackmoney/goal/controller/GoalsController.java
+++ b/src/main/java/fun/trackmoney/goal/controller/GoalsController.java
@@ -5,7 +5,6 @@ import fun.trackmoney.goal.dtos.GoalsResponseDTO;
 import fun.trackmoney.goal.service.GoalsService;
 import fun.trackmoney.utils.response.ApiResponse;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/fun/trackmoney/goal/controller/GoalsController.java
+++ b/src/main/java/fun/trackmoney/goal/controller/GoalsController.java
@@ -42,14 +42,14 @@ public class GoalsController {
   @GetMapping("/{id}")
   public ResponseEntity<ApiResponse<GoalsResponseDTO>> findById(@PathVariable Integer id){
     return ResponseEntity.status(HttpStatus.OK).body(
-        new ApiResponse<>(true, "All goals", goalsService.findById(id), null));
+        new ApiResponse<>(true, "Get goal", goalsService.findById(id), null));
   }
 
   @PutMapping("/{id}")
   public ResponseEntity<ApiResponse<GoalsResponseDTO>> update(@PathVariable Integer id,
                                                                 @RequestBody CreateGoalsDTO dto){
     return ResponseEntity.status(HttpStatus.OK).body(
-        new ApiResponse<>(true, "All goals", goalsService.update(id, dto), null));
+        new ApiResponse<>(true, "Update goals", goalsService.update(id, dto), null));
   }
 
 
@@ -57,6 +57,6 @@ public class GoalsController {
   public ResponseEntity<ApiResponse<String>> delete(@PathVariable Integer id){
     goalsService.deleteById(id);
     return ResponseEntity.status(HttpStatus.OK).body(
-        new ApiResponse<>(true, "All goals","Goals deleted", null));
+        new ApiResponse<>(true, "deleted goals","Goals deleted", null));
   }
 }

--- a/src/main/java/fun/trackmoney/goal/controller/GoalsController.java
+++ b/src/main/java/fun/trackmoney/goal/controller/GoalsController.java
@@ -1,0 +1,63 @@
+package fun.trackmoney.goal.controller;
+
+import fun.trackmoney.goal.dtos.CreateGoalsDTO;
+import fun.trackmoney.goal.dtos.GoalsResponseDTO;
+import fun.trackmoney.goal.service.GoalsService;
+import fun.trackmoney.utils.response.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("goals")
+public class GoalsController {
+
+  private final GoalsService goalsService;
+
+  public GoalsController(GoalsService goalsService) {
+    this.goalsService = goalsService;
+  }
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<GoalsResponseDTO>> create(@RequestBody CreateGoalsDTO dto){
+    return ResponseEntity.status(HttpStatus.CREATED).body(
+        new ApiResponse<>(true, "Goals Created!", goalsService.createGoals(dto), null));
+  }
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<List<GoalsResponseDTO>>> findAll(){
+    return ResponseEntity.status(HttpStatus.OK).body(
+        new ApiResponse<>(true, "All goals", goalsService.findAllGoals(), null));
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<ApiResponse<GoalsResponseDTO>> findById(@PathVariable Integer id){
+    return ResponseEntity.status(HttpStatus.OK).body(
+        new ApiResponse<>(true, "All goals", goalsService.findById(id), null));
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<ApiResponse<GoalsResponseDTO>> update(@PathVariable Integer id,
+                                                                @RequestBody CreateGoalsDTO dto){
+    return ResponseEntity.status(HttpStatus.OK).body(
+        new ApiResponse<>(true, "All goals", goalsService.update(id, dto), null));
+  }
+
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<ApiResponse<String>> delete(@PathVariable Integer id){
+    goalsService.deleteById(id);
+    return ResponseEntity.status(HttpStatus.OK).body(
+        new ApiResponse<>(true, "All goals","Goals deleted", null));
+  }
+}

--- a/src/main/java/fun/trackmoney/goal/dtos/CreateGoalsDTO.java
+++ b/src/main/java/fun/trackmoney/goal/dtos/CreateGoalsDTO.java
@@ -1,0 +1,10 @@
+package fun.trackmoney.goal.dtos;
+
+import java.math.BigDecimal;
+
+public record CreateGoalsDTO(String goal,
+                             Integer accountId,
+                             BigDecimal targetAmount,
+                             BigDecimal currentAmount) {
+}
+

--- a/src/main/java/fun/trackmoney/goal/dtos/GoalsResponseDTO.java
+++ b/src/main/java/fun/trackmoney/goal/dtos/GoalsResponseDTO.java
@@ -1,0 +1,13 @@
+package fun.trackmoney.goal.dtos;
+
+import fun.trackmoney.account.dtos.AccountResponseDTO;
+
+import java.math.BigDecimal;
+
+public record GoalsResponseDTO(Integer goalsId,
+                               String goal,
+                               AccountResponseDTO account,
+                               BigDecimal targetAmount,
+                               BigDecimal currentAmount,
+                               Integer progress) {
+}

--- a/src/main/java/fun/trackmoney/goal/entity/GoalsEntity.java
+++ b/src/main/java/fun/trackmoney/goal/entity/GoalsEntity.java
@@ -68,16 +68,15 @@ public class GoalsEntity {
    * @param account The account associated with the goal.
    * @param targetAmount The target amount for the goal.
    * @param currentAmount The current amount towards the goal.
-   * @param progress The progress percentage towards the goal.
    */
   public GoalsEntity(Integer goalsId, String goal, AccountEntity account, BigDecimal targetAmount,
-                     BigDecimal currentAmount, Integer progress) {
+                     BigDecimal currentAmount) {
     this.goalsId = goalsId;
     this.goal = goal;
     this.account = account;
     this.targetAmount = targetAmount;
     this.currentAmount = currentAmount;
-    this.progress = progress;
+    updateProgress();
   }
 
   /**
@@ -150,6 +149,7 @@ public class GoalsEntity {
    */
   public void setTargetAmount(BigDecimal targetAmount) {
     this.targetAmount = targetAmount;
+    updateProgress();
   }
 
   /**
@@ -168,6 +168,7 @@ public class GoalsEntity {
    */
   public void setCurrentAmount(BigDecimal currentAmount) {
     this.currentAmount = currentAmount;
+    updateProgress();
   }
 
   /**
@@ -179,12 +180,14 @@ public class GoalsEntity {
     return progress;
   }
 
-  /**
-   * Sets the progress percentage toward the goal.
-   *
-   * @param progress The progress percentage to set.
-   */
-  public void setProgress(Integer progress) {
-    this.progress = progress;
+  public void updateProgress() {
+    if (targetAmount != null && currentAmount != null && targetAmount.compareTo(BigDecimal.ZERO) > 0) {
+      BigDecimal progressDecimal = currentAmount
+          .divide(targetAmount, 2, BigDecimal.ROUND_HALF_UP)
+          .multiply(BigDecimal.valueOf(100));
+      this.progress = progressDecimal.intValue();
+    } else {
+      this.progress = 0;
+    }
   }
 }

--- a/src/main/java/fun/trackmoney/goal/exception/GoalsNotFoundException.java
+++ b/src/main/java/fun/trackmoney/goal/exception/GoalsNotFoundException.java
@@ -1,0 +1,24 @@
+package fun.trackmoney.goal.exception;
+
+import fun.trackmoney.utils.CustomFieldError;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GoalsNotFoundException extends RuntimeException {
+  private final List<CustomFieldError> errors = new ArrayList<>();
+
+  public GoalsNotFoundException(String message) {
+    super(message);
+    this.errors.add(new CustomFieldError("Goal", message));
+  }
+
+  public GoalsNotFoundException(List<CustomFieldError> errors) {
+    super("Account not found!");
+    this.errors.addAll(errors);
+  }
+
+  public List<CustomFieldError> getErrors() {
+    return errors;
+  }
+}

--- a/src/main/java/fun/trackmoney/goal/mapper/GoalsMapper.java
+++ b/src/main/java/fun/trackmoney/goal/mapper/GoalsMapper.java
@@ -1,0 +1,18 @@
+package fun.trackmoney.goal.mapper;
+
+import fun.trackmoney.goal.dtos.CreateGoalsDTO;
+import fun.trackmoney.goal.dtos.GoalsResponseDTO;
+import fun.trackmoney.goal.entity.GoalsEntity;
+import org.mapstruct.Mapper;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface GoalsMapper {
+  GoalsEntity toEntity(CreateGoalsDTO dto);
+
+  GoalsResponseDTO toResponseDTO(GoalsEntity entity);
+
+  List<GoalsResponseDTO> toListResponseDTO(List<GoalsEntity> entity);
+
+}

--- a/src/main/java/fun/trackmoney/goal/repository/GoalsRepository.java
+++ b/src/main/java/fun/trackmoney/goal/repository/GoalsRepository.java
@@ -1,0 +1,7 @@
+package fun.trackmoney.goal.repository;
+
+import fun.trackmoney.goal.entity.GoalsEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GoalsRepository extends JpaRepository<GoalsEntity, Integer> {
+}

--- a/src/main/java/fun/trackmoney/goal/service/GoalsService.java
+++ b/src/main/java/fun/trackmoney/goal/service/GoalsService.java
@@ -6,6 +6,7 @@ import fun.trackmoney.account.service.AccountService;
 import fun.trackmoney.goal.dtos.CreateGoalsDTO;
 import fun.trackmoney.goal.dtos.GoalsResponseDTO;
 import fun.trackmoney.goal.entity.GoalsEntity;
+import fun.trackmoney.goal.exception.GoalsNotFoundException;
 import fun.trackmoney.goal.mapper.GoalsMapper;
 import fun.trackmoney.goal.repository.GoalsRepository;
 import org.springframework.stereotype.Service;
@@ -45,12 +46,12 @@ public class GoalsService {
 
   public GoalsResponseDTO findById(Integer id) {
     return goalsMapper.toResponseDTO(goalsRepository.findById(id)
-        .orElseThrow(() -> new RuntimeException("Goals not found!")));
+        .orElseThrow(() -> new GoalsNotFoundException("Goals not found!")));
   }
 
   public GoalsResponseDTO update(Integer id, CreateGoalsDTO dto) {
     GoalsEntity goals =  goalsRepository.findById(id)
-        .orElseThrow(() -> new RuntimeException("Goals not found!"));
+        .orElseThrow(() -> new GoalsNotFoundException("Goals not found!"));
     goals.setGoal(dto.goal());
     goals.setCurrentAmount(dto.currentAmount());
     goals.setTargetAmount(dto.targetAmount());

--- a/src/main/java/fun/trackmoney/goal/service/GoalsService.java
+++ b/src/main/java/fun/trackmoney/goal/service/GoalsService.java
@@ -20,7 +20,11 @@ public class GoalsService {
   private final AccountMapper accountMapper;
   private final GoalsMapper goalsMapper;
 
-  public GoalsService(GoalsRepository goalsRepository, AccountService accountService, AccountMapper accountMapper, GoalsMapper goalsMapper) {
+  public GoalsService(GoalsRepository goalsRepository,
+                      AccountService accountService,
+                      AccountMapper accountMapper,
+                      GoalsMapper goalsMapper) {
+
     this.goalsRepository = goalsRepository;
     this.accountService = accountService;
     this.accountMapper = accountMapper;

--- a/src/main/java/fun/trackmoney/goal/service/GoalsService.java
+++ b/src/main/java/fun/trackmoney/goal/service/GoalsService.java
@@ -1,0 +1,59 @@
+package fun.trackmoney.goal.service;
+
+import fun.trackmoney.account.entity.AccountEntity;
+import fun.trackmoney.account.mapper.AccountMapper;
+import fun.trackmoney.account.service.AccountService;
+import fun.trackmoney.goal.dtos.CreateGoalsDTO;
+import fun.trackmoney.goal.dtos.GoalsResponseDTO;
+import fun.trackmoney.goal.entity.GoalsEntity;
+import fun.trackmoney.goal.mapper.GoalsMapper;
+import fun.trackmoney.goal.repository.GoalsRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class GoalsService {
+
+  private final GoalsRepository goalsRepository;
+  private final AccountService accountService;
+  private final AccountMapper accountMapper;
+  private final GoalsMapper goalsMapper;
+
+  public GoalsService(GoalsRepository goalsRepository, AccountService accountService, AccountMapper accountMapper, GoalsMapper goalsMapper) {
+    this.goalsRepository = goalsRepository;
+    this.accountService = accountService;
+    this.accountMapper = accountMapper;
+    this.goalsMapper = goalsMapper;
+  }
+
+  public GoalsResponseDTO createGoals(CreateGoalsDTO dto){
+    GoalsEntity goals = goalsMapper.toEntity(dto);
+    AccountEntity account = accountMapper.accountResponseToEntity(accountService.findAccountById(dto.accountId()));
+    goals.setAccount(account);
+    return goalsMapper.toResponseDTO(goalsRepository.save(goals));
+  }
+
+  public List<GoalsResponseDTO> findAllGoals(){
+    List<GoalsEntity> list = goalsRepository.findAll();
+    return goalsMapper.toListResponseDTO(list);
+  }
+
+  public GoalsResponseDTO findById(Integer id) {
+    return goalsMapper.toResponseDTO(goalsRepository.findById(id)
+        .orElseThrow(() -> new RuntimeException("Goals not found!")));
+  }
+
+  public GoalsResponseDTO update(Integer id, CreateGoalsDTO dto) {
+    GoalsEntity goals =  goalsRepository.findById(id)
+        .orElseThrow(() -> new RuntimeException("Goals not found!"));
+    goals.setGoal(dto.goal());
+    goals.setCurrentAmount(dto.currentAmount());
+    goals.setTargetAmount(dto.targetAmount());
+    return goalsMapper.toResponseDTO(goalsRepository.save(goals));
+  }
+
+  public void deleteById(Integer id) {
+    goalsRepository.deleteById(id);
+  }
+}

--- a/src/test/java/fun/trackmoney/config/exception/RestExceptionHandlerTest.java
+++ b/src/test/java/fun/trackmoney/config/exception/RestExceptionHandlerTest.java
@@ -3,6 +3,7 @@ package fun.trackmoney.config.exception;
 import fun.trackmoney.account.exception.AccountNotFoundException;
 import fun.trackmoney.auth.exception.LoginException;
 import fun.trackmoney.category.exception.CategoryNotFoundException;
+import fun.trackmoney.goal.exception.GoalsNotFoundException;
 import fun.trackmoney.transaction.exception.TransactionNotFoundException;
 import fun.trackmoney.user.exception.EmailAlreadyExistsException;
 import fun.trackmoney.user.exception.UserNotFoundException;
@@ -191,6 +192,24 @@ class RestExceptionHandlerTest {
     CustomFieldError error = apiResponse.getErrors().get(0);
     assertEquals("Transaction", error.getField());
     assertEquals("Transaction not found.", error.getMessage());
+  }
+
+  @Test
+  void goalsNotFound_shouldReturnNotFoundWithError() {
+    GoalsNotFoundException exception = new GoalsNotFoundException("Goals not found.");
+    ResponseEntity<ApiResponse<List<CustomFieldError>>> response = restExceptionHandler.goalsNotFound(exception);
+
+    assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    ApiResponse<List<CustomFieldError>> apiResponse = response.getBody();
+    assertNotNull(apiResponse);
+    assertFalse(apiResponse.isSuccess());
+    assertEquals("Goals not found.", apiResponse.getMessage());
+    assertNull(apiResponse.getData());
+    assertNotNull(apiResponse.getErrors());
+    assertEquals(1, (apiResponse.getErrors()).size());
+    CustomFieldError error = apiResponse.getErrors().get(0);
+    assertEquals("Goal", error.getField());
+    assertEquals("Goals not found.", error.getMessage());
   }
 
 }

--- a/src/test/java/fun/trackmoney/goal/controller/GoalsControllerTest.java
+++ b/src/test/java/fun/trackmoney/goal/controller/GoalsControllerTest.java
@@ -1,0 +1,119 @@
+package fun.trackmoney.goal.controller;
+
+import fun.trackmoney.account.dtos.AccountResponseDTO;
+import fun.trackmoney.goal.dtos.CreateGoalsDTO;
+import fun.trackmoney.goal.dtos.GoalsResponseDTO;
+import fun.trackmoney.goal.service.GoalsService;
+import fun.trackmoney.user.dtos.UserResponseDTO;
+import fun.trackmoney.utils.response.ApiResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class GoalsControllerTest {
+
+  private GoalsService goalsService;
+  private GoalsController controller;
+
+  private GoalsResponseDTO goalResponse;
+
+  @BeforeEach
+  void setUp() {
+    goalsService = mock(GoalsService.class);
+    controller = new GoalsController(goalsService);
+
+    UserResponseDTO user = new UserResponseDTO(UUID.randomUUID(), "User", "user@email.com");
+    AccountResponseDTO account = new AccountResponseDTO(1, user, "Conta 1", new BigDecimal("1000"), true);
+
+    goalResponse = new GoalsResponseDTO(1, "Viagem", account, new BigDecimal("1000"), new BigDecimal("200"), 20);
+  }
+
+  @Test
+  void create_shouldReturnCreatedResponse() {
+    CreateGoalsDTO dto = new CreateGoalsDTO("Viagem", 1, new BigDecimal("1000"), new BigDecimal("200"));
+
+    when(goalsService.createGoals(dto)).thenReturn(goalResponse);
+
+    var response = controller.create(dto);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    ApiResponse<GoalsResponseDTO> body = response.getBody();
+    assertThat(body).isNotNull();
+    assertThat(body.getSuccess()).isTrue();
+    assertThat(body.getMessage()).isEqualTo("Goals Created!");
+    assertThat(body.getData().goal()).isEqualTo("Viagem");
+
+    verify(goalsService).createGoals(dto);
+  }
+
+  @Test
+  void findAll_shouldReturnAllGoals() {
+    when(goalsService.findAllGoals()).thenReturn(List.of(goalResponse));
+
+    var response = controller.findAll();
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    ApiResponse<List<GoalsResponseDTO>> body = response.getBody();
+    assertThat(body).isNotNull();
+    assertThat(body.getSuccess()).isTrue();
+    assertThat(body.getData()).hasSize(1);
+    assertThat(body.getData().get(0).goal()).isEqualTo("Viagem");
+
+    verify(goalsService).findAllGoals();
+  }
+
+  @Test
+  void findById_shouldReturnGoal() {
+    when(goalsService.findById(1)).thenReturn(goalResponse);
+
+    var response = controller.findById(1);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    ApiResponse<GoalsResponseDTO> body = response.getBody();
+    assertThat(body).isNotNull();
+    assertThat(body.getSuccess()).isTrue();
+    assertThat(body.getData().goal()).isEqualTo("Viagem");
+
+    verify(goalsService).findById(1);
+  }
+
+  @Test
+  void update_shouldReturnUpdatedGoal() {
+    CreateGoalsDTO dto = new CreateGoalsDTO("Casa", 1, new BigDecimal("3000"), new BigDecimal("500"));
+    GoalsResponseDTO updated = new GoalsResponseDTO(1, "Casa", goalResponse.account(), new BigDecimal("3000"), new BigDecimal("500"), 17);
+
+    when(goalsService.update(1, dto)).thenReturn(updated);
+
+    var response = controller.update(1, dto);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    ApiResponse<GoalsResponseDTO> body = response.getBody();
+    assertThat(body).isNotNull();
+    assertThat(body.getSuccess()).isTrue();
+    assertThat(body.getData().goal()).isEqualTo("Casa");
+
+    verify(goalsService).update(1, dto);
+  }
+
+  @Test
+  void delete_shouldReturnSuccessMessage() {
+    doNothing().when(goalsService).deleteById(1);
+
+    var response = controller.delete(1);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    ApiResponse<String> body = response.getBody();
+    assertThat(body).isNotNull();
+    assertThat(body.getSuccess()).isTrue();
+    assertThat(body.getData()).isEqualTo("Goals deleted");
+
+    verify(goalsService).deleteById(1);
+  }
+}

--- a/src/test/java/fun/trackmoney/goal/service/GoalsServiceTest.java
+++ b/src/test/java/fun/trackmoney/goal/service/GoalsServiceTest.java
@@ -1,0 +1,162 @@
+package fun.trackmoney.goal.service;
+
+import fun.trackmoney.account.dtos.AccountResponseDTO;
+import fun.trackmoney.account.entity.AccountEntity;
+import fun.trackmoney.account.exception.AccountNotFoundException;
+import fun.trackmoney.account.mapper.AccountMapper;
+import fun.trackmoney.account.service.AccountService;
+import fun.trackmoney.goal.dtos.CreateGoalsDTO;
+import fun.trackmoney.goal.dtos.GoalsResponseDTO;
+import fun.trackmoney.goal.entity.GoalsEntity;
+import fun.trackmoney.goal.exception.GoalsNotFoundException;
+import fun.trackmoney.goal.mapper.GoalsMapper;
+import fun.trackmoney.goal.repository.GoalsRepository;
+import fun.trackmoney.user.dtos.UserResponseDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+class GoalsServiceTest {
+
+  @Mock
+  private GoalsRepository goalsRepository;
+  @Mock
+  private AccountService accountService;
+  @Mock
+  private AccountMapper accountMapper;
+  @Mock
+  private GoalsMapper goalsMapper;
+  @InjectMocks
+  private GoalsService goalsService;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  void createGoals_shouldSaveAndReturnResponse() {
+    CreateGoalsDTO dto = new CreateGoalsDTO("Viagem", 1, new BigDecimal("1000"), new BigDecimal("100"));
+    GoalsEntity goalsEntity = new GoalsEntity();
+    GoalsEntity savedGoals = new GoalsEntity();
+    AccountEntity accountEntity = new AccountEntity();
+
+    UserResponseDTO userDTO = new UserResponseDTO(UUID.randomUUID(), "user@email.com", "User");
+    AccountResponseDTO accountDTO = new AccountResponseDTO(1, userDTO, "Conta 1", new BigDecimal("5000"), true);
+
+    GoalsResponseDTO responseDTO = new GoalsResponseDTO(
+        1,
+        "Viagem",
+        accountDTO,
+        new BigDecimal("1000"),
+        new BigDecimal("100"),
+        10
+    );
+
+    when(goalsMapper.toEntity(dto)).thenReturn(goalsEntity);
+    when(accountService.findAccountById(dto.accountId())).thenReturn(accountDTO);
+    when(accountMapper.accountResponseToEntity(accountDTO)).thenReturn(accountEntity);
+    when(goalsRepository.save(goalsEntity)).thenReturn(savedGoals);
+    when(goalsMapper.toResponseDTO(savedGoals)).thenReturn(responseDTO);
+
+    GoalsResponseDTO result = goalsService.createGoals(dto);
+
+    assertThat(result).isEqualTo(responseDTO);
+    assertThat(goalsEntity.getAccount()).isEqualTo(accountEntity);
+  }
+
+  @Test
+  void findAllGoals_shouldReturnListOfResponses() {
+    GoalsEntity g1 = new GoalsEntity();
+    GoalsEntity g2 = new GoalsEntity();
+    List<GoalsEntity> entities = List.of(g1, g2);
+
+    UserResponseDTO userDTO = new UserResponseDTO(UUID.randomUUID(), "user@email.com", "User");
+
+    AccountResponseDTO acc = new AccountResponseDTO(1, userDTO, "Conta", new BigDecimal("2000"), true);
+
+    List<GoalsResponseDTO> dtoList = List.of(
+        new GoalsResponseDTO(1, "Meta1", acc, new BigDecimal("1000"), new BigDecimal("500"), 50),
+        new GoalsResponseDTO(2, "Meta2", acc, new BigDecimal("2000"), new BigDecimal("1000"), 50)
+    );
+
+    when(goalsRepository.findAll()).thenReturn(entities);
+    when(goalsMapper.toListResponseDTO(entities)).thenReturn(dtoList);
+
+    List<GoalsResponseDTO> result = goalsService.findAllGoals();
+
+    assertThat(result)
+        .hasSize(2)
+        .isEqualTo(dtoList);
+  }
+
+  @Test
+  void findById_shouldReturnGoalResponse_whenExists() {
+    GoalsEntity entity = new GoalsEntity();
+    UserResponseDTO user = new UserResponseDTO(UUID.randomUUID(), "Usuário", "mail@mail.com");
+    AccountResponseDTO acc = new AccountResponseDTO(1, user, "Conta", new BigDecimal("2000"), true);
+    GoalsResponseDTO dto = new GoalsResponseDTO(1, "Meta", acc, new BigDecimal("1000"), new BigDecimal("500"), 50);
+
+    when(goalsRepository.findById(1)).thenReturn(Optional.of(entity));
+    when(goalsMapper.toResponseDTO(entity)).thenReturn(dto);
+
+    GoalsResponseDTO result = goalsService.findById(1);
+
+    assertThat(result).isEqualTo(dto);
+  }
+
+  @Test
+  void findById_shouldThrowException_whenNotFound() {
+    when(goalsRepository.findById(1)).thenReturn(Optional.empty());
+
+    assertThrows(GoalsNotFoundException.class, () -> goalsService.findById(1));
+  }
+
+  @Test
+  void update_shouldUpdateAndReturnGoalResponse_whenFound() {
+    CreateGoalsDTO dto = new CreateGoalsDTO("Nova Meta", 1, new BigDecimal("3000"), new BigDecimal("1000"));
+    GoalsEntity entity = new GoalsEntity();
+    GoalsEntity saved = new GoalsEntity();
+
+    UserResponseDTO user = new UserResponseDTO(UUID.randomUUID(), "Usuário","mail@mail.com");
+    AccountResponseDTO acc = new AccountResponseDTO(1, user, "Conta", new BigDecimal("2000"), true);
+    GoalsResponseDTO responseDTO = new GoalsResponseDTO(1, "Nova Meta", acc, new BigDecimal("3000"), new BigDecimal("1000"), 33);
+
+    when(goalsRepository.findById(1)).thenReturn(Optional.of(entity));
+    when(goalsRepository.save(entity)).thenReturn(saved);
+    when(goalsMapper.toResponseDTO(saved)).thenReturn(responseDTO);
+
+    GoalsResponseDTO result = goalsService.update(1, dto);
+
+    assertThat(result).isEqualTo(responseDTO);
+    assertThat(entity.getGoal()).isEqualTo(dto.goal());
+    assertThat(entity.getCurrentAmount()).isEqualTo(dto.currentAmount());
+    assertThat(entity.getTargetAmount()).isEqualTo(dto.targetAmount());
+  }
+
+  @Test
+  void update_shouldThrowException_whenNotFound() {
+    CreateGoalsDTO dto = new CreateGoalsDTO("Meta", 1, new BigDecimal("1000"), new BigDecimal("100"));
+
+    when(goalsRepository.findById(1)).thenReturn(Optional.empty());
+
+    assertThrows(GoalsNotFoundException.class, () -> goalsService.update(1, dto));
+  }
+
+  @Test
+  void deleteById_shouldCallRepositoryDelete() {
+    goalsService.deleteById(1);
+    verify(goalsRepository).deleteById(1);
+  }
+}

--- a/src/test/java/fun/trackmoney/goal/service/GoalsServiceTest.java
+++ b/src/test/java/fun/trackmoney/goal/service/GoalsServiceTest.java
@@ -2,7 +2,6 @@ package fun.trackmoney.goal.service;
 
 import fun.trackmoney.account.dtos.AccountResponseDTO;
 import fun.trackmoney.account.entity.AccountEntity;
-import fun.trackmoney.account.exception.AccountNotFoundException;
 import fun.trackmoney.account.mapper.AccountMapper;
 import fun.trackmoney.account.service.AccountService;
 import fun.trackmoney.goal.dtos.CreateGoalsDTO;


### PR DESCRIPTION
## Pull Request Description

> Implemented full CRUD functionality for Goals, including controller, service, DTOs, entity updates, repository, and mapper configuration.

### Related Task
> #34 

### What was done?
> Created GoalsController with the following endpoints: POST, GET, GET/{id}, PUT/{id}, and DELETE/{id}
> Added CreateGoalsDTO and GoalsResponseDTO for data transfer
> Updated GoalsEntity to include automatic progress calculation via updateProgress()
> Implemented GoalsMapper using MapStruct for converting between entity and DTO
> Created GoalsRepository extending JPA Repository
> Implemented GoalsService containing the business logic for handling goals

### Tests
- [x] I tested the new feature/fix locally.
- [x] I write the unit tests.

### How to Test
> Send a POST request to /goals with a valid body to create a new goal.
> Use GET /goals to retrieve all goals.
> Use GET /goals/{id} to fetch a specific goal by ID.
> Use PUT /goals/{id} to update an existing goal.
> Use DELETE /goals/{id} to delete a goal.

### Dependencies
> This feature depends on the Account module being functional, as goals are linked to existing accounts
> AccountMapper and AccountService must be available in the application context

No external dependencies were added
### Useful Links
> If necessary, add links to articles, documentation, or other issues that help understand the changes.