### PR TITLE
Feat/budgets

### DIFF
--- a/src/main/java/fun/trackmoney/budget/controller/BudgetsController.java
+++ b/src/main/java/fun/trackmoney/budget/controller/BudgetsController.java
@@ -1,0 +1,62 @@
+package fun.trackmoney.budget.controller;
+
+import fun.trackmoney.budget.dtos.BudgetCreateDTO;
+import fun.trackmoney.budget.dtos.BudgetResponseDTO;
+import fun.trackmoney.budget.service.BudgetsService;
+import fun.trackmoney.utils.response.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("budgets")
+public class BudgetsController {
+
+  private final BudgetsService budgetsService;
+
+  public BudgetsController(BudgetsService budgetsService) {
+    this.budgetsService = budgetsService;
+  }
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<BudgetResponseDTO>> create(@RequestBody BudgetCreateDTO dto) {
+    return ResponseEntity.status(HttpStatus.CREATED).body(
+        new ApiResponse<>(true, "Budget created", budgetsService.create(dto), null));
+  }
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<List<BudgetResponseDTO>>> findAll() {
+    var list = budgetsService.findAll();
+    return ResponseEntity.status(HttpStatus.OK).body(
+        new ApiResponse<>(true, "Get all Budget",list , null));
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<ApiResponse<BudgetResponseDTO>> findById(@PathVariable Integer id) {
+    return ResponseEntity.status(HttpStatus.OK).body(
+        new ApiResponse<>(true, "Get Budget by Id", budgetsService.findById(id), null));
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<ApiResponse<String>> deleteById(@PathVariable Integer id) {
+    budgetsService.findById(id);
+    return ResponseEntity.status(HttpStatus.OK).body(
+        new ApiResponse<>(true, "Delete Budget by id", "Budget deleted", null));
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<ApiResponse<BudgetResponseDTO>> updateById(@PathVariable Integer id, @RequestBody BudgetCreateDTO dto) {
+    return ResponseEntity.status(HttpStatus.OK).body(
+        new ApiResponse<>(true, "Update Budget", budgetsService.update(dto,id), null));
+  }
+}
+

--- a/src/main/java/fun/trackmoney/budget/controller/BudgetsController.java
+++ b/src/main/java/fun/trackmoney/budget/controller/BudgetsController.java
@@ -54,7 +54,8 @@ public class BudgetsController {
   }
 
   @PutMapping("/{id}")
-  public ResponseEntity<ApiResponse<BudgetResponseDTO>> updateById(@PathVariable Integer id, @RequestBody BudgetCreateDTO dto) {
+  public ResponseEntity<ApiResponse<BudgetResponseDTO>> updateById(@PathVariable Integer id,
+                                                                   @RequestBody BudgetCreateDTO dto) {
     return ResponseEntity.status(HttpStatus.OK).body(
         new ApiResponse<>(true, "Update Budget", budgetsService.update(dto,id), null));
   }

--- a/src/main/java/fun/trackmoney/budget/dtos/BudgetCreateDTO.java
+++ b/src/main/java/fun/trackmoney/budget/dtos/BudgetCreateDTO.java
@@ -1,0 +1,11 @@
+package fun.trackmoney.budget.dtos;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record BudgetCreateDTO(Integer categoryId,
+                              UUID userId,
+                              Integer accountId,
+                              BigDecimal targetAmount,
+                              Integer resetDay) {
+}

--- a/src/main/java/fun/trackmoney/budget/dtos/BudgetResponseDTO.java
+++ b/src/main/java/fun/trackmoney/budget/dtos/BudgetResponseDTO.java
@@ -1,0 +1,13 @@
+package fun.trackmoney.budget.dtos;
+
+import fun.trackmoney.account.dtos.AccountResponseDTO;
+import fun.trackmoney.category.entity.CategoryEntity;
+
+import java.math.BigDecimal;
+
+public record BudgetResponseDTO (Integer budgetId,
+                                 CategoryEntity category,
+                                 AccountResponseDTO account,
+                                 BigDecimal targetAmount,
+                                 Integer resetDay) {
+}

--- a/src/main/java/fun/trackmoney/budget/entity/BudgetsEntity.java
+++ b/src/main/java/fun/trackmoney/budget/entity/BudgetsEntity.java
@@ -46,7 +46,11 @@ public class BudgetsEntity {
 
   }
 
-  public BudgetsEntity(Integer budgetId, CategoryEntity category, UserEntity userEntity, BigDecimal targetAmount, Integer resetDay) {
+  public BudgetsEntity(Integer budgetId,
+                       CategoryEntity category,
+                       UserEntity userEntity,
+                       BigDecimal targetAmount,
+                       Integer resetDay) {
     this.budgetId = budgetId;
     this.category = category;
     this.userEntity = userEntity;

--- a/src/main/java/fun/trackmoney/budget/entity/BudgetsEntity.java
+++ b/src/main/java/fun/trackmoney/budget/entity/BudgetsEntity.java
@@ -1,0 +1,104 @@
+package fun.trackmoney.budget.entity;
+
+import fun.trackmoney.account.entity.AccountEntity;
+import fun.trackmoney.category.entity.CategoryEntity;
+import fun.trackmoney.user.entity.UserEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "tb_budget")
+public class BudgetsEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "budget_id")
+  private Integer budgetId;
+
+  @ManyToOne
+  @JoinColumn(name = "category_id")
+  private CategoryEntity category;
+
+  @ManyToOne
+  @JoinColumn(name = "account_id")
+  private AccountEntity account;
+  @ManyToOne
+  @JoinColumn(name = "user_id")
+  private UserEntity userEntity;
+
+  private BigDecimal targetAmount;
+  @Column(name = "reset_day")
+  private Integer resetDay;
+
+  public AccountEntity getAccount() {
+    return account;
+  }
+
+  public BudgetsEntity() {
+
+  }
+
+  public BudgetsEntity(Integer budgetId, CategoryEntity category, UserEntity userEntity, BigDecimal targetAmount, Integer resetDay) {
+    this.budgetId = budgetId;
+    this.category = category;
+    this.userEntity = userEntity;
+    this.targetAmount = targetAmount;
+    this.resetDay = resetDay;
+  }
+
+  public void setAccount(AccountEntity account) {
+    this.account = account;
+  }
+
+  public BudgetsEntity(UserEntity userEntity) {
+    this.userEntity = userEntity;
+  }
+
+  public Integer getBudgetId() {
+    return budgetId;
+  }
+
+  public void setBudgetId(Integer budgetId) {
+    this.budgetId = budgetId;
+  }
+
+  public CategoryEntity getCategory() {
+    return category;
+  }
+
+  public void setCategory(CategoryEntity category) {
+    this.category = category;
+  }
+
+  public BigDecimal getTargetAmount() {
+    return targetAmount;
+  }
+
+  public void setTargetAmount(BigDecimal targetAmount) {
+    this.targetAmount = targetAmount;
+  }
+
+  public Integer getResetDay() {
+    return resetDay;
+  }
+
+  public void setResetDay(Integer resetDay) {
+    this.resetDay = resetDay;
+  }
+
+  public UserEntity getUserEntity() {
+    return userEntity;
+  }
+
+  public void setUserEntity(UserEntity userEntity) {
+    this.userEntity = userEntity;
+  }
+}

--- a/src/main/java/fun/trackmoney/budget/exception/BudgetsNotFoundException.java
+++ b/src/main/java/fun/trackmoney/budget/exception/BudgetsNotFoundException.java
@@ -1,0 +1,24 @@
+package fun.trackmoney.budget.exception;
+
+import fun.trackmoney.utils.CustomFieldError;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BudgetsNotFoundException extends RuntimeException {
+  private final List<CustomFieldError> errors = new ArrayList<>();
+
+  public BudgetsNotFoundException(String message) {
+    super(message);
+    this.errors.add(new CustomFieldError("Budgets", message));
+  }
+
+  public BudgetsNotFoundException(List<CustomFieldError> errors) {
+    super("Budgets not found!");
+    this.errors.addAll(errors);
+  }
+
+  public List<CustomFieldError> getErrors() {
+    return errors;
+  }
+}

--- a/src/main/java/fun/trackmoney/budget/mapper/BudgetMapper.java
+++ b/src/main/java/fun/trackmoney/budget/mapper/BudgetMapper.java
@@ -1,0 +1,18 @@
+package fun.trackmoney.budget.mapper;
+
+import fun.trackmoney.budget.dtos.BudgetCreateDTO;
+import fun.trackmoney.budget.dtos.BudgetResponseDTO;
+import fun.trackmoney.budget.entity.BudgetsEntity;
+import org.mapstruct.Mapper;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface BudgetMapper {
+
+  BudgetsEntity createDtoTOEntity(BudgetCreateDTO dto);
+
+  BudgetResponseDTO entityToResponseDTO(BudgetsEntity entity);
+
+  List<BudgetResponseDTO> entityListToResponseList(List<BudgetsEntity> entityList);
+}

--- a/src/main/java/fun/trackmoney/budget/repository/BudgetsRepository.java
+++ b/src/main/java/fun/trackmoney/budget/repository/BudgetsRepository.java
@@ -1,0 +1,7 @@
+package fun.trackmoney.budget.repository;
+
+import fun.trackmoney.budget.entity.BudgetsEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BudgetsRepository extends JpaRepository<BudgetsEntity, Integer> {
+}

--- a/src/main/java/fun/trackmoney/budget/service/BudgetsService.java
+++ b/src/main/java/fun/trackmoney/budget/service/BudgetsService.java
@@ -5,6 +5,7 @@ import fun.trackmoney.account.service.AccountService;
 import fun.trackmoney.budget.dtos.BudgetCreateDTO;
 import fun.trackmoney.budget.dtos.BudgetResponseDTO;
 import fun.trackmoney.budget.entity.BudgetsEntity;
+import fun.trackmoney.budget.exception.BudgetsNotFoundException;
 import fun.trackmoney.budget.mapper.BudgetMapper;
 import fun.trackmoney.budget.repository.BudgetsRepository;
 import fun.trackmoney.category.service.CategoryService;
@@ -52,12 +53,12 @@ public class BudgetsService {
 
   public BudgetResponseDTO findById(Integer id) {
     return budgetMapper.entityToResponseDTO(budgetsRepository.findById(id)
-        .orElseThrow(() -> new RuntimeException("Budget not found")));
+        .orElseThrow(() -> new BudgetsNotFoundException("Budget not found")));
   }
 
   public BudgetResponseDTO update(BudgetCreateDTO dto, Integer id) {
-    BudgetsEntity existingBudget = budgetsRepository.findById(id)
-        .orElseThrow(() -> new RuntimeException("Budget not found"));
+    budgetsRepository.findById(id)
+        .orElseThrow(() -> new BudgetsNotFoundException(("Budget not found")));
 
     BudgetsEntity budgets = budgetMapper.createDtoTOEntity(dto);
     budgets.setBudgetId(id);

--- a/src/main/java/fun/trackmoney/budget/service/BudgetsService.java
+++ b/src/main/java/fun/trackmoney/budget/service/BudgetsService.java
@@ -56,6 +56,9 @@ public class BudgetsService {
   }
 
   public BudgetResponseDTO update(BudgetCreateDTO dto, Integer id) {
+    BudgetsEntity existingBudget = budgetsRepository.findById(id)
+        .orElseThrow(() -> new RuntimeException("Budget not found"));
+
     BudgetsEntity budgets = budgetMapper.createDtoTOEntity(dto);
     budgets.setBudgetId(id);
     budgets.setUserEntity(userService.findUserById(dto.userId()));

--- a/src/main/java/fun/trackmoney/budget/service/BudgetsService.java
+++ b/src/main/java/fun/trackmoney/budget/service/BudgetsService.java
@@ -1,6 +1,5 @@
 package fun.trackmoney.budget.service;
 
-import fun.trackmoney.account.entity.AccountEntity;
 import fun.trackmoney.account.mapper.AccountMapper;
 import fun.trackmoney.account.service.AccountService;
 import fun.trackmoney.budget.dtos.BudgetCreateDTO;
@@ -8,7 +7,6 @@ import fun.trackmoney.budget.dtos.BudgetResponseDTO;
 import fun.trackmoney.budget.entity.BudgetsEntity;
 import fun.trackmoney.budget.mapper.BudgetMapper;
 import fun.trackmoney.budget.repository.BudgetsRepository;
-import fun.trackmoney.category.entity.CategoryEntity;
 import fun.trackmoney.category.service.CategoryService;
 import fun.trackmoney.user.service.UserService;
 import org.springframework.stereotype.Service;
@@ -25,7 +23,12 @@ public class BudgetsService {
   private final CategoryService categoryService;
   private final UserService userService;
 
-  public BudgetsService(BudgetsRepository budgetsRepository, BudgetMapper budgetMapper, AccountService accountService, AccountMapper accountMapper, CategoryService categoryService, UserService userService) {
+  public BudgetsService(BudgetsRepository budgetsRepository,
+                        BudgetMapper budgetMapper,
+                        AccountService accountService,
+                        AccountMapper accountMapper,
+                        CategoryService categoryService,
+                        UserService userService) {
     this.budgetsRepository = budgetsRepository;
     this.budgetMapper = budgetMapper;
     this.accountService = accountService;
@@ -44,7 +47,6 @@ public class BudgetsService {
   }
 
   public List<BudgetResponseDTO> findAll() {
-    var list = budgetsRepository.findAll();
     return budgetMapper.entityListToResponseList(budgetsRepository.findAll());
   }
 

--- a/src/main/java/fun/trackmoney/budget/service/BudgetsService.java
+++ b/src/main/java/fun/trackmoney/budget/service/BudgetsService.java
@@ -1,0 +1,71 @@
+package fun.trackmoney.budget.service;
+
+import fun.trackmoney.account.entity.AccountEntity;
+import fun.trackmoney.account.mapper.AccountMapper;
+import fun.trackmoney.account.service.AccountService;
+import fun.trackmoney.budget.dtos.BudgetCreateDTO;
+import fun.trackmoney.budget.dtos.BudgetResponseDTO;
+import fun.trackmoney.budget.entity.BudgetsEntity;
+import fun.trackmoney.budget.mapper.BudgetMapper;
+import fun.trackmoney.budget.repository.BudgetsRepository;
+import fun.trackmoney.category.entity.CategoryEntity;
+import fun.trackmoney.category.service.CategoryService;
+import fun.trackmoney.user.service.UserService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class BudgetsService {
+
+  private final BudgetsRepository budgetsRepository;
+  private final BudgetMapper budgetMapper;
+  private final AccountService accountService;
+  private final AccountMapper accountMapper;
+  private final CategoryService categoryService;
+  private final UserService userService;
+
+  public BudgetsService(BudgetsRepository budgetsRepository, BudgetMapper budgetMapper, AccountService accountService, AccountMapper accountMapper, CategoryService categoryService, UserService userService) {
+    this.budgetsRepository = budgetsRepository;
+    this.budgetMapper = budgetMapper;
+    this.accountService = accountService;
+    this.accountMapper = accountMapper;
+    this.categoryService = categoryService;
+    this.userService = userService;
+  }
+
+  public BudgetResponseDTO create(BudgetCreateDTO dto) {
+    BudgetsEntity budgets = budgetMapper.createDtoTOEntity(dto);
+
+    budgets.setUserEntity(userService.findUserById(dto.userId()));
+    budgets.setAccount(accountMapper.accountResponseToEntity(accountService.findAccountById(dto.accountId())));
+    budgets.setCategory(categoryService.findById(dto.categoryId()));
+    return budgetMapper.entityToResponseDTO(budgetsRepository.save(budgets));
+  }
+
+  public List<BudgetResponseDTO> findAll() {
+    var list = budgetsRepository.findAll();
+    return budgetMapper.entityListToResponseList(budgetsRepository.findAll());
+  }
+
+  public BudgetResponseDTO findById(Integer id) {
+    return budgetMapper.entityToResponseDTO(budgetsRepository.findById(id)
+        .orElseThrow(() -> new RuntimeException("Budget not found")));
+  }
+
+  public BudgetResponseDTO update(BudgetCreateDTO dto, Integer id) {
+    BudgetsEntity budgets = budgetMapper.createDtoTOEntity(dto);
+    budgets.setBudgetId(id);
+    budgets.setUserEntity(userService.findUserById(dto.userId()));
+    budgets.setAccount(accountMapper.accountResponseToEntity(accountService.findAccountById(dto.accountId())));
+    budgets.setCategory(categoryService.findById(dto.categoryId()));
+    budgets.setTargetAmount(dto.targetAmount());
+    budgets.setResetDay(dto.resetDay());
+
+    return budgetMapper.entityToResponseDTO(budgetsRepository.save(budgets));
+  }
+
+  public void deleteById(Integer id) {
+    budgetsRepository.deleteById(id);
+  }
+}

--- a/src/main/java/fun/trackmoney/config/exception/RestExceptionHandler.java
+++ b/src/main/java/fun/trackmoney/config/exception/RestExceptionHandler.java
@@ -2,6 +2,7 @@ package fun.trackmoney.config.exception;
 
 import fun.trackmoney.account.exception.AccountNotFoundException;
 import fun.trackmoney.auth.exception.LoginException;
+import fun.trackmoney.budget.exception.BudgetsNotFoundException;
 import fun.trackmoney.category.exception.CategoryNotFoundException;
 import fun.trackmoney.goal.exception.GoalsNotFoundException;
 import fun.trackmoney.transaction.exception.TransactionNotFoundException;
@@ -96,6 +97,14 @@ public class RestExceptionHandler {
 
   @ExceptionHandler(GoalsNotFoundException.class)
   public ResponseEntity<ApiResponse<List<CustomFieldError>>> goalsNotFound(GoalsNotFoundException ex) {
+    return ResponseEntity
+        .status(HttpStatus.NOT_FOUND)
+        .body(new ApiResponse<>(false, ex.getMessage(), null, ex.getErrors())
+        );
+  }
+
+  @ExceptionHandler(BudgetsNotFoundException.class)
+  public ResponseEntity<ApiResponse<List<CustomFieldError>>> budgetsNotFound(BudgetsNotFoundException ex) {
     return ResponseEntity
         .status(HttpStatus.NOT_FOUND)
         .body(new ApiResponse<>(false, ex.getMessage(), null, ex.getErrors())

--- a/src/main/resources/db/migration/V2__create_budget_schema.sql
+++ b/src/main/resources/db/migration/V2__create_budget_schema.sql
@@ -1,0 +1,12 @@
+CREATE TABLE tb_budget(
+    budget_id SERIAL PRIMARY KEY,
+    user_id UUID NOT NULL,
+    account_id SERIAL NOT NULL,
+    category_id SERIAL NOT NULL,
+    target_amount NUMERIC(19, 4) NOT NULL DEFAULT 0.0000,
+    reset_day INTEGER,
+
+    CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES tb_user(user_id),
+    CONSTRAINT fk_account FOREIGN KEY (account_id) REFERENCES tb_account(account_id),
+    CONSTRAINT fk_category FOREIGN KEY (category_id) REFERENCES tb_category(category_id)
+);

--- a/src/test/java/fun/trackmoney/budget/controller/BudgetsControllerTest.java
+++ b/src/test/java/fun/trackmoney/budget/controller/BudgetsControllerTest.java
@@ -1,0 +1,123 @@
+package fun.trackmoney.budget.controller;
+
+import fun.trackmoney.budget.dtos.BudgetCreateDTO;
+import fun.trackmoney.budget.dtos.BudgetResponseDTO;
+import fun.trackmoney.budget.service.BudgetsService;
+import fun.trackmoney.utils.response.ApiResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+class BudgetsControllerTest {
+
+  @Mock
+  private BudgetsService budgetsService;
+
+  @InjectMocks
+  private BudgetsController budgetsController;
+
+  private BudgetCreateDTO createDTO;
+  private BudgetResponseDTO responseDTO;
+  private Integer budgetId;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    UUID userId = UUID.randomUUID();
+    budgetId = 1;
+    createDTO = new BudgetCreateDTO(10, userId, 20, BigDecimal.valueOf(1000), 5);
+    responseDTO = new BudgetResponseDTO(budgetId, null, null, BigDecimal.valueOf(1000), 5);
+  }
+
+  @Test
+  void create_shouldReturnCreatedAndBudgetResponse() {
+    when(budgetsService.create(createDTO)).thenReturn(responseDTO);
+
+    ResponseEntity<ApiResponse<BudgetResponseDTO>> response = budgetsController.create(createDTO);
+
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    assertNotNull(response.getBody());
+    assertTrue(response.getBody().isSuccess());
+    assertEquals("Budget created", response.getBody().getMessage());
+    assertEquals(responseDTO, response.getBody().getData());
+    assertNull(response.getBody().getErrors());
+    verify(budgetsService, times(1)).create(createDTO);
+  }
+
+  @Test
+  void findAll_shouldReturnOkAndListOfBudgetResponses() {
+    List<BudgetResponseDTO> budgetList = Collections.singletonList(responseDTO);
+    when(budgetsService.findAll()).thenReturn(budgetList);
+
+    ResponseEntity<ApiResponse<List<BudgetResponseDTO>>> response = budgetsController.findAll();
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertNotNull(response.getBody());
+    assertTrue(response.getBody().isSuccess());
+    assertEquals("Get all Budget", response.getBody().getMessage());
+    assertEquals(budgetList, response.getBody().getData());
+    assertNull(response.getBody().getErrors());
+    verify(budgetsService, times(1)).findAll();
+  }
+
+  @Test
+  void findById_shouldReturnOkAndBudgetResponse() {
+    when(budgetsService.findById(budgetId)).thenReturn(responseDTO);
+
+    ResponseEntity<ApiResponse<BudgetResponseDTO>> response = budgetsController.findById(budgetId);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertNotNull(response.getBody());
+    assertTrue(response.getBody().isSuccess());
+    assertEquals("Get Budget by Id", response.getBody().getMessage());
+    assertEquals(responseDTO, response.getBody().getData());
+    assertNull(response.getBody().getErrors());
+    verify(budgetsService, times(1)).findById(budgetId);
+  }
+
+  @Test
+  void deleteById_shouldReturnOkAndSuccessMessage() {
+    ResponseEntity<ApiResponse<String>> response = budgetsController.deleteById(budgetId);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertNotNull(response.getBody());
+    assertTrue(response.getBody().isSuccess());
+    assertEquals("Delete Budget by id", response.getBody().getMessage());
+    assertEquals("Budget deleted", response.getBody().getData());
+    assertNull(response.getBody().getErrors());
+    verify(budgetsService, times(1)).findById(budgetId); // Para garantir que o findById foi chamado
+  }
+
+  @Test
+  void updateById_shouldReturnOkAndUpdatedBudgetResponse() {
+    int updateId = 1;
+    BudgetCreateDTO updateDTO = new BudgetCreateDTO(11, UUID.randomUUID(), 21, BigDecimal.valueOf(1500), 6);
+    BudgetResponseDTO updatedResponseDTO = new BudgetResponseDTO(updateId, null, null, BigDecimal.valueOf(1500), 6);
+    when(budgetsService.update(updateDTO, updateId)).thenReturn(updatedResponseDTO);
+
+    ResponseEntity<ApiResponse<BudgetResponseDTO>> response = budgetsController.updateById(updateId, updateDTO);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertNotNull(response.getBody());
+    assertTrue(response.getBody().isSuccess());
+    assertEquals("Update Budget", response.getBody().getMessage());
+    assertEquals(updatedResponseDTO, response.getBody().getData());
+    assertNull(response.getBody().getErrors());
+    verify(budgetsService, times(1)).update(updateDTO, updateId);
+  }
+}

--- a/src/test/java/fun/trackmoney/budget/service/BudgetsServiceTest.java
+++ b/src/test/java/fun/trackmoney/budget/service/BudgetsServiceTest.java
@@ -7,6 +7,7 @@ import fun.trackmoney.account.service.AccountService;
 import fun.trackmoney.budget.dtos.BudgetCreateDTO;
 import fun.trackmoney.budget.dtos.BudgetResponseDTO;
 import fun.trackmoney.budget.entity.BudgetsEntity;
+import fun.trackmoney.budget.exception.BudgetsNotFoundException;
 import fun.trackmoney.budget.mapper.BudgetMapper;
 import fun.trackmoney.budget.repository.BudgetsRepository;
 import fun.trackmoney.category.entity.CategoryEntity;
@@ -148,7 +149,7 @@ class BudgetsServiceTest {
     int budgetId = 1;
     when(budgetsRepository.findById(budgetId)).thenReturn(Optional.empty());
 
-    RuntimeException exception = assertThrows(RuntimeException.class, () -> budgetsService.findById(budgetId));
+    BudgetsNotFoundException exception = assertThrows(BudgetsNotFoundException.class, () -> budgetsService.findById(budgetId));
     assertEquals("Budget not found", exception.getMessage());
     verify(budgetsRepository, times(1)).findById(budgetId);
     verify(budgetMapper, never()).entityToResponseDTO(any());
@@ -200,7 +201,7 @@ class BudgetsServiceTest {
 
     when(budgetsRepository.findById(budgetIdToUpdate)).thenReturn(Optional.empty());
 
-    RuntimeException exception = assertThrows(RuntimeException.class,
+    BudgetsNotFoundException exception = assertThrows(BudgetsNotFoundException.class,
         () -> budgetsService.update(updateDTO, budgetIdToUpdate));
     assertEquals("Budget not found", exception.getMessage());
     verify(budgetsRepository, times(1)).findById(budgetIdToUpdate);

--- a/src/test/java/fun/trackmoney/budget/service/BudgetsServiceTest.java
+++ b/src/test/java/fun/trackmoney/budget/service/BudgetsServiceTest.java
@@ -75,6 +75,13 @@ class BudgetsServiceTest {
 
   @Test
   void create_shouldReturnBudgetResponseDTO() {
+    budgetEntity.setBudgetId(99);
+    budgetEntity.setCategory(categoryEntity);
+    budgetEntity.setUserEntity(userEntity);
+    budgetEntity.setTargetAmount(BigDecimal.valueOf(1234));
+    budgetEntity.setResetDay(7);
+    budgetEntity.setAccount(accountEntity);
+
     when(budgetMapper.createDtoTOEntity(createDTO)).thenReturn(budgetEntity);
     when(userService.findUserById(userId)).thenReturn(userEntity);
     when(accountService.findAccountById(20)).thenReturn(accountResponseDTO);
@@ -86,6 +93,12 @@ class BudgetsServiceTest {
     BudgetResponseDTO result = budgetsService.create(createDTO);
 
     assertNotNull(result);
+    assertEquals(99, budgetEntity.getBudgetId());
+    assertEquals(categoryEntity, budgetEntity.getCategory());
+    assertEquals(userEntity, budgetEntity.getUserEntity());
+    assertEquals(BigDecimal.valueOf(1234), budgetEntity.getTargetAmount());
+    assertEquals(7, budgetEntity.getResetDay());
+    assertEquals(accountEntity, budgetEntity.getAccount());
     assertEquals(budgetResponseDTO, result);
     verify(budgetsRepository, times(1)).save(budgetEntity);
     verify(budgetMapper, times(1)).createDtoTOEntity(createDTO);

--- a/src/test/java/fun/trackmoney/budget/service/BudgetsServiceTest.java
+++ b/src/test/java/fun/trackmoney/budget/service/BudgetsServiceTest.java
@@ -1,0 +1,222 @@
+package fun.trackmoney.budget.service;
+
+import fun.trackmoney.account.dtos.AccountResponseDTO;
+import fun.trackmoney.account.entity.AccountEntity;
+import fun.trackmoney.account.mapper.AccountMapper;
+import fun.trackmoney.account.service.AccountService;
+import fun.trackmoney.budget.dtos.BudgetCreateDTO;
+import fun.trackmoney.budget.dtos.BudgetResponseDTO;
+import fun.trackmoney.budget.entity.BudgetsEntity;
+import fun.trackmoney.budget.mapper.BudgetMapper;
+import fun.trackmoney.budget.repository.BudgetsRepository;
+import fun.trackmoney.category.entity.CategoryEntity;
+import fun.trackmoney.category.service.CategoryService;
+import fun.trackmoney.user.dtos.UserResponseDTO;
+import fun.trackmoney.user.entity.UserEntity;
+import fun.trackmoney.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class BudgetsServiceTest {
+
+  @Mock
+  private BudgetsRepository budgetsRepository;
+  @Mock
+  private BudgetMapper budgetMapper;
+  @Mock
+  private AccountService accountService;
+  @Mock
+  private AccountMapper accountMapper;
+  @Mock
+  private CategoryService categoryService;
+  @Mock
+  private UserService userService;
+
+  @InjectMocks
+  private BudgetsService budgetsService;
+
+  private UUID userId;
+  private BudgetCreateDTO createDTO;
+  private BudgetsEntity budgetEntity;
+  private UserEntity userEntity;
+  private UserResponseDTO userResponseDTO;
+  private AccountResponseDTO accountResponseDTO;
+  private AccountEntity accountEntity;
+  private CategoryEntity categoryEntity;
+  private BudgetResponseDTO budgetResponseDTO;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+
+    userId = UUID.randomUUID();
+    createDTO = new BudgetCreateDTO(10, userId, 20, BigDecimal.valueOf(1000), 5);
+    budgetEntity = new BudgetsEntity();
+    userEntity = new UserEntity();
+    userResponseDTO = new UserResponseDTO(userId, "testUser", "email@test");
+    accountResponseDTO = new AccountResponseDTO(20, userResponseDTO, "true", BigDecimal.valueOf(1000), true);
+    accountEntity = new AccountEntity();
+    categoryEntity = new CategoryEntity();
+    budgetResponseDTO = new BudgetResponseDTO(1, categoryEntity, accountResponseDTO, BigDecimal.valueOf(1000), 5);
+  }
+
+  @Test
+  void create_shouldReturnBudgetResponseDTO() {
+    when(budgetMapper.createDtoTOEntity(createDTO)).thenReturn(budgetEntity);
+    when(userService.findUserById(userId)).thenReturn(userEntity);
+    when(accountService.findAccountById(20)).thenReturn(accountResponseDTO);
+    when(accountMapper.accountResponseToEntity(accountResponseDTO)).thenReturn(accountEntity);
+    when(categoryService.findById(10)).thenReturn(categoryEntity);
+    when(budgetsRepository.save(budgetEntity)).thenReturn(budgetEntity);
+    when(budgetMapper.entityToResponseDTO(budgetEntity)).thenReturn(budgetResponseDTO);
+
+    BudgetResponseDTO result = budgetsService.create(createDTO);
+
+    assertNotNull(result);
+    assertEquals(budgetResponseDTO, result);
+    verify(budgetsRepository, times(1)).save(budgetEntity);
+    verify(budgetMapper, times(1)).createDtoTOEntity(createDTO);
+    verify(userService, times(1)).findUserById(userId);
+    verify(accountService, times(1)).findAccountById(20);
+    verify(accountMapper, times(1)).accountResponseToEntity(accountResponseDTO);
+    verify(categoryService, times(1)).findById(10);
+    verify(budgetMapper, times(1)).entityToResponseDTO(budgetEntity);
+  }
+
+  @Test
+  void findAll_shouldReturnEmptyList_whenNoBudgetsExist() {
+    when(budgetsRepository.findAll()).thenReturn(Collections.emptyList());
+    when(budgetMapper.entityListToResponseList(Collections.emptyList())).thenReturn(Collections.emptyList());
+
+    List<BudgetResponseDTO> result = budgetsService.findAll();
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+    verify(budgetsRepository, times(1)).findAll();
+    verify(budgetMapper, times(1)).entityListToResponseList(Collections.emptyList());
+  }
+
+  @Test
+  void findAll_shouldReturnListOfBudgetResponseDTO() {
+    BudgetsEntity entity = new BudgetsEntity();
+    BudgetResponseDTO dto = new BudgetResponseDTO(1, new CategoryEntity(),
+        new AccountResponseDTO(1, userResponseDTO, "test", BigDecimal.valueOf(100), true),
+        BigDecimal.TEN, 10);
+    List<BudgetsEntity> entities = List.of(entity);
+    List<BudgetResponseDTO> dtos = List.of(dto);
+
+    when(budgetsRepository.findAll()).thenReturn(entities);
+    when(budgetMapper.entityListToResponseList(entities)).thenReturn(dtos);
+
+    List<BudgetResponseDTO> result = budgetsService.findAll();
+
+    assertNotNull(result);
+    assertEquals(1, result.size());
+    assertEquals(dtos, result);
+    verify(budgetsRepository, times(1)).findAll();
+    verify(budgetMapper, times(1)).entityListToResponseList(entities);
+  }
+
+  @Test
+  void findById_shouldReturnBudgetResponseDTO_whenExists() {
+    int budgetId = 1;
+    when(budgetsRepository.findById(budgetId)).thenReturn(Optional.of(budgetEntity));
+    when(budgetMapper.entityToResponseDTO(budgetEntity)).thenReturn(budgetResponseDTO);
+
+    BudgetResponseDTO result = budgetsService.findById(budgetId);
+
+    assertNotNull(result);
+    assertEquals(budgetResponseDTO, result);
+    verify(budgetsRepository, times(1)).findById(budgetId);
+    verify(budgetMapper, times(1)).entityToResponseDTO(budgetEntity);
+  }
+
+  @Test
+  void findById_shouldThrowException_whenNotExists() {
+    int budgetId = 1;
+    when(budgetsRepository.findById(budgetId)).thenReturn(Optional.empty());
+
+    RuntimeException exception = assertThrows(RuntimeException.class, () -> budgetsService.findById(budgetId));
+    assertEquals("Budget not found", exception.getMessage());
+    verify(budgetsRepository, times(1)).findById(budgetId);
+    verify(budgetMapper, never()).entityToResponseDTO(any());
+  }
+
+  @Test
+  void update_shouldReturnUpdatedBudgetResponseDTO_whenBudgetExists() {
+    int budgetIdToUpdate = 1;
+    BudgetCreateDTO updateDTO = new BudgetCreateDTO(11, userId, 21, BigDecimal.valueOf(1500), 6);
+    BudgetsEntity existingEntity = new BudgetsEntity();
+    existingEntity.setBudgetId(budgetIdToUpdate);
+    UserResponseDTO updatedUserResponseDTO = new UserResponseDTO(userId, "updatedUser", "updated@test");
+    AccountResponseDTO updatedAccountDTO = new AccountResponseDTO(21, updatedUserResponseDTO, "false", BigDecimal.valueOf(1500), false);
+    AccountEntity updatedAccountEntity = new AccountEntity();
+    CategoryEntity updatedCategory = new CategoryEntity();
+    BudgetResponseDTO updatedResponse = new BudgetResponseDTO(budgetIdToUpdate, updatedCategory,
+        updatedAccountDTO, BigDecimal.valueOf(1500), 6);
+    BudgetsEntity updatedEntity = new BudgetsEntity();
+    updatedEntity.setBudgetId(budgetIdToUpdate);
+
+    when(budgetsRepository.findById(budgetIdToUpdate)).thenReturn(Optional.of(existingEntity));
+    when(budgetMapper.createDtoTOEntity(updateDTO)).thenReturn(updatedEntity);
+    when(userService.findUserById(userId)).thenReturn(userEntity);
+    when(accountService.findAccountById(21)).thenReturn(updatedAccountDTO);
+    when(accountMapper.accountResponseToEntity(updatedAccountDTO)).thenReturn(updatedAccountEntity);
+    when(categoryService.findById(11)).thenReturn(updatedCategory);
+    when(budgetsRepository.save(updatedEntity)).thenReturn(updatedEntity);
+    when(budgetMapper.entityToResponseDTO(updatedEntity)).thenReturn(updatedResponse);
+
+    BudgetResponseDTO result = budgetsService.update(updateDTO, budgetIdToUpdate);
+
+    assertNotNull(result);
+    assertEquals(updatedResponse, result);
+    assertEquals(budgetIdToUpdate, updatedEntity.getBudgetId());
+    verify(budgetsRepository, times(1)).findById(budgetIdToUpdate);
+    verify(budgetMapper, times(1)).createDtoTOEntity(updateDTO);
+    verify(userService, times(1)).findUserById(userId);
+    verify(accountService, times(1)).findAccountById(21);
+    verify(accountMapper, times(1)).accountResponseToEntity(updatedAccountDTO);
+    verify(categoryService, times(1)).findById(11);
+    verify(budgetsRepository, times(1)).save(updatedEntity);
+    verify(budgetMapper, times(1)).entityToResponseDTO(updatedEntity);
+  }
+
+  @Test
+  void update_shouldThrowException_whenBudgetNotExists() {
+    int budgetIdToUpdate = 1;
+    BudgetCreateDTO updateDTO = new BudgetCreateDTO(11, userId, 21, BigDecimal.valueOf(1500), 6);
+
+    when(budgetsRepository.findById(budgetIdToUpdate)).thenReturn(Optional.empty());
+
+    RuntimeException exception = assertThrows(RuntimeException.class,
+        () -> budgetsService.update(updateDTO, budgetIdToUpdate));
+    assertEquals("Budget not found", exception.getMessage());
+    verify(budgetsRepository, times(1)).findById(budgetIdToUpdate);
+    verify(budgetMapper, never()).createDtoTOEntity(any());
+    verify(userService, never()).findUserById(any());
+    verify(accountService, never()).findAccountById(anyInt());
+    verify(accountMapper, never()).accountResponseToEntity(any());
+    verify(categoryService, never()).findById(anyInt());
+    verify(budgetsRepository, never()).save(any());
+    verify(budgetMapper, never()).entityToResponseDTO(any());
+  }
+
+  @Test
+  void deleteById_shouldCallRepositoryDelete() {
+    int budgetId = 5;
+    budgetsService.deleteById(budgetId);
+    verify(budgetsRepository, times(1)).deleteById(budgetId);
+  }
+}

--- a/src/test/java/fun/trackmoney/config/exception/RestExceptionHandlerTest.java
+++ b/src/test/java/fun/trackmoney/config/exception/RestExceptionHandlerTest.java
@@ -2,6 +2,7 @@ package fun.trackmoney.config.exception;
 
 import fun.trackmoney.account.exception.AccountNotFoundException;
 import fun.trackmoney.auth.exception.LoginException;
+import fun.trackmoney.budget.exception.BudgetsNotFoundException;
 import fun.trackmoney.category.exception.CategoryNotFoundException;
 import fun.trackmoney.goal.exception.GoalsNotFoundException;
 import fun.trackmoney.transaction.exception.TransactionNotFoundException;
@@ -212,4 +213,21 @@ class RestExceptionHandlerTest {
     assertEquals("Goals not found.", error.getMessage());
   }
 
+  @Test
+  void budgetsNotFound_shouldReturnNotFoundWithError() {
+    BudgetsNotFoundException exception = new BudgetsNotFoundException("Budgets not found.");
+    ResponseEntity<ApiResponse<List<CustomFieldError>>> response = restExceptionHandler.budgetsNotFound(exception);
+
+    assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    ApiResponse<List<CustomFieldError>> apiResponse = response.getBody();
+    assertNotNull(apiResponse);
+    assertFalse(apiResponse.isSuccess());
+    assertEquals("Budgets not found.", apiResponse.getMessage());
+    assertNull(apiResponse.getData());
+    assertNotNull(apiResponse.getErrors());
+    assertEquals(1, (apiResponse.getErrors()).size());
+    CustomFieldError error = apiResponse.getErrors().get(0);
+    assertEquals("Budgets", error.getField());
+    assertEquals("Budgets not found.", error.getMessage());
+  }
 }


### PR DESCRIPTION
## Pull Request Description

> Implements the full CRUD functionality for the Budgets module, including REST endpoints, service layer, entity, DTOs, MapStruct mapper, JPA repository, and Flyway migration for the `tb_budget` table.

### Related Task  
> N/A (add issue number if applicable, e.g., Resolves #45)

### What was done?

>  
- Added `BudgetsController` with the following endpoints:  
  - `POST /budgets` – Create a new budget  
  - `GET /budgets` – Retrieve all budgets  
  - `GET /budgets/{id}` – Retrieve a budget by ID  
  - `PUT /budgets/{id}` – Update a budget  
  - `DELETE /budgets/{id}` – Delete a budget  

- Created DTOs:
  - `BudgetCreateDTO` for input
  - `BudgetResponseDTO` for output

- Implemented `BudgetsEntity` with relationships to:
  - `UserEntity`
  - `AccountEntity`
  - `CategoryEntity`

- Added `BudgetMapper` using MapStruct

- Created `BudgetsService` to handle business logic and integration with:
  - `UserService`
  - `AccountService`
  - `CategoryService`

- Created `BudgetsRepository` using Spring Data JPA

- Added Flyway migration: `V2__create_budget_schema.sql`

### Tests  
- [x] I tested the new feature/fix locally.  
- [x] I write the unit tests.

### How to Test

>  
1. Start the application with a clean database to apply the Flyway migration `V2__create_budget_schema.sql`  
2. Use Postman, Insomnia, or a similar tool to test the following endpoints:  
   - `POST /budgets`  
   - `GET /budgets`  
   - `GET /budgets/{id}`  
   - `PUT /budgets/{id}`  
   - `DELETE /budgets/{id}`  
3. Verify the relationships with user, account, and category are properly resolved in the response.

### Dependencies

> This feature depends on the existence of the following tables:  
- `tb_user`  
- `tb_account`  
- `tb_category`  

These are required due to foreign key constraints in the `tb_budget` table.

### Useful Links  
> N/A (add any relevant documentation, articles, or issue links if needed)
