### PR TITLE
refactor: replace MapStruct with hand-written mappers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,12 +83,7 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.mapstruct</groupId>
-			<artifactId>mapstruct</artifactId>
-			<version>1.5.5.Final</version>
-		</dependency>
-		<dependency>
+<dependency>
 			<groupId>com.auth0</groupId>
 			<artifactId>java-jwt</artifactId>
 			<version>4.4.0</version>
@@ -173,13 +168,6 @@
 				<configuration>
 					<source>${java.version}</source>
 					<target>${java.version}</target>
-					<annotationProcessorPaths>
-						<path>
-							<groupId>org.mapstruct</groupId>
-							<artifactId>mapstruct-processor</artifactId>
-							<version>1.5.5.Final</version>
-						</path>
-					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/fun/trackmoney/mapper/AccountMapper.java
+++ b/src/main/java/fun/trackmoney/mapper/AccountMapper.java
@@ -4,21 +4,75 @@ import fun.trackmoney.dto.account.AccountRequestDTO;
 import fun.trackmoney.dto.account.AccountResponseDTO;
 import fun.trackmoney.dto.account.AccountUpdateRequestDTO;
 import fun.trackmoney.entity.AccountEntity;
-import org.mapstruct.Mapper;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Mapper(componentModel = "spring")
-public interface AccountMapper {
-  AccountEntity accountRequestToAccountEntity(AccountRequestDTO accountRequestDTO);
+@Component
+public class AccountMapper {
 
-  AccountEntity accountUpdateRequestToAccountEntity(AccountUpdateRequestDTO accountRequestDTO);
+  private final UserMapper userMapper;
 
-  AccountResponseDTO accountEntityToAccountResponse(AccountEntity accountEntity);
+  public AccountMapper(UserMapper userMapper) {
+    this.userMapper = userMapper;
+  }
 
-  List<AccountResponseDTO> accountEntityListToAccountResponseList(List<AccountEntity> entities);
+  public AccountEntity accountRequestToAccountEntity(AccountRequestDTO accountRequestDTO) {
+    if (accountRequestDTO == null) {
+      return null;
+    }
+    AccountEntity entity = new AccountEntity();
+    entity.setName(accountRequestDTO.name());
+    entity.setBalance(accountRequestDTO.balance());
+    return entity;
+  }
 
-  AccountEntity accountResponseToEntity(AccountResponseDTO accountById);
+  public AccountEntity accountUpdateRequestToAccountEntity(AccountUpdateRequestDTO accountRequestDTO) {
+    if (accountRequestDTO == null) {
+      return null;
+    }
+    AccountEntity entity = new AccountEntity();
+    entity.setName(accountRequestDTO.name());
+    return entity;
+  }
 
-  AccountUpdateRequestDTO toAccountRequest(AccountEntity account);
+  public AccountResponseDTO accountEntityToAccountResponse(AccountEntity accountEntity) {
+    if (accountEntity == null) {
+      return null;
+    }
+    return new AccountResponseDTO(
+        accountEntity.getAccountId(),
+        userMapper.userEntityToUserResponseDto(accountEntity.getUser()),
+        accountEntity.getName(),
+        accountEntity.getBalance()
+    );
+  }
+
+  public List<AccountResponseDTO> accountEntityListToAccountResponseList(List<AccountEntity> entities) {
+    if (entities == null) {
+      return null;
+    }
+    return entities.stream()
+        .map(this::accountEntityToAccountResponse)
+        .toList();
+  }
+
+  public AccountEntity accountResponseToEntity(AccountResponseDTO accountById) {
+    if (accountById == null) {
+      return null;
+    }
+    AccountEntity entity = new AccountEntity();
+    entity.setAccountId(accountById.accountId());
+    entity.setUser(userMapper.userResponseDtoToEntity(accountById.user()));
+    entity.setName(accountById.name());
+    entity.setBalance(accountById.balance());
+    return entity;
+  }
+
+  public AccountUpdateRequestDTO toAccountRequest(AccountEntity account) {
+    if (account == null) {
+      return null;
+    }
+    return new AccountUpdateRequestDTO(account.getName());
+  }
 }

--- a/src/main/java/fun/trackmoney/mapper/BudgetHistoryMapper.java
+++ b/src/main/java/fun/trackmoney/mapper/BudgetHistoryMapper.java
@@ -2,17 +2,40 @@ package fun.trackmoney.mapper;
 
 import fun.trackmoney.dto.budget.BudgetHistoryResponseDTO;
 import fun.trackmoney.entity.BudgetHistoryEntity;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Mapper(componentModel = "spring")
-public interface BudgetHistoryMapper {
+@Component
+public class BudgetHistoryMapper {
 
-  @Mapping(target = "transactions", ignore = true)
-  BudgetHistoryResponseDTO entityToResponseDTO(BudgetHistoryEntity entity);
+  public BudgetHistoryResponseDTO entityToResponseDTO(BudgetHistoryEntity entity) {
+    if (entity == null) {
+      return null;
+    }
+    return new BudgetHistoryResponseDTO(
+        entity.getHistoryId(),
+        null,
+        entity.getCategory(),
+        entity.getReferenceMonth(),
+        entity.getReferenceYear(),
+        entity.getPercent(),
+        entity.getTargetAmount(),
+        entity.getSpentAmount(),
+        entity.getRemainingAmount(),
+        entity.getTotalIncome(),
+        null,
+        entity.getStatus(),
+        entity.getCreatedAt()
+    );
+  }
 
-  @Mapping(target = "transactions", ignore = true)
-  List<BudgetHistoryResponseDTO> entityListToResponseList(List<BudgetHistoryEntity> entityList);
+  public List<BudgetHistoryResponseDTO> entityListToResponseList(List<BudgetHistoryEntity> entityList) {
+    if (entityList == null) {
+      return null;
+    }
+    return entityList.stream()
+        .map(this::entityToResponseDTO)
+        .toList();
+  }
 }

--- a/src/main/java/fun/trackmoney/mapper/BudgetMapper.java
+++ b/src/main/java/fun/trackmoney/mapper/BudgetMapper.java
@@ -3,16 +3,49 @@ package fun.trackmoney.mapper;
 import fun.trackmoney.dto.budget.BudgetCreateDTO;
 import fun.trackmoney.dto.budget.BudgetResponseDTO;
 import fun.trackmoney.entity.BudgetsEntity;
-import org.mapstruct.Mapper;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Mapper(componentModel = "spring")
-public interface BudgetMapper {
+@Component
+public class BudgetMapper {
 
-  BudgetsEntity createDtoTOEntity(BudgetCreateDTO dto);
+  private final AccountMapper accountMapper;
 
-  BudgetResponseDTO entityToResponseDTO(BudgetsEntity entity);
+  public BudgetMapper(AccountMapper accountMapper) {
+    this.accountMapper = accountMapper;
+  }
 
-  List<BudgetResponseDTO> entityListToResponseList(List<BudgetsEntity> entityList);
+  public BudgetsEntity createDtoTOEntity(BudgetCreateDTO dto) {
+    if (dto == null) {
+      return null;
+    }
+    BudgetsEntity entity = new BudgetsEntity();
+    entity.setPercent(dto.percent());
+    return entity;
+  }
+
+  public BudgetResponseDTO entityToResponseDTO(BudgetsEntity entity) {
+    if (entity == null) {
+      return null;
+    }
+    return new BudgetResponseDTO(
+        entity.getBudgetId(),
+        entity.getCategory(),
+        accountMapper.accountEntityToAccountResponse(entity.getAccount()),
+        entity.getPercent(),
+        null,
+        null,
+        null
+    );
+  }
+
+  public List<BudgetResponseDTO> entityListToResponseList(List<BudgetsEntity> entityList) {
+    if (entityList == null) {
+      return null;
+    }
+    return entityList.stream()
+        .map(this::entityToResponseDTO)
+        .toList();
+  }
 }

--- a/src/main/java/fun/trackmoney/mapper/CategoryMapper.java
+++ b/src/main/java/fun/trackmoney/mapper/CategoryMapper.java
@@ -2,13 +2,30 @@ package fun.trackmoney.mapper;
 
 import fun.trackmoney.dto.category.CategoryResponseDTO;
 import fun.trackmoney.entity.CategoryEntity;
-import org.mapstruct.Mapper;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Mapper(componentModel = "spring")
-public interface CategoryMapper {
-  CategoryResponseDTO categoryEntityToCategoryResponse(CategoryEntity entity);
+@Component
+public class CategoryMapper {
 
-  List<CategoryResponseDTO> categoryEntityListToResponseList(List<CategoryEntity> entities);
+  public CategoryResponseDTO categoryEntityToCategoryResponse(CategoryEntity entity) {
+    if (entity == null) {
+      return null;
+    }
+    return new CategoryResponseDTO(
+        entity.getCategoryId(),
+        entity.getName(),
+        entity.getColor()
+    );
+  }
+
+  public List<CategoryResponseDTO> categoryEntityListToResponseList(List<CategoryEntity> entities) {
+    if (entities == null) {
+      return null;
+    }
+    return entities.stream()
+        .map(this::categoryEntityToCategoryResponse)
+        .toList();
+  }
 }

--- a/src/main/java/fun/trackmoney/mapper/PotsMapper.java
+++ b/src/main/java/fun/trackmoney/mapper/PotsMapper.java
@@ -3,18 +3,43 @@ package fun.trackmoney.mapper;
 import fun.trackmoney.dto.pots.CreatePotsDTO;
 import fun.trackmoney.dto.pots.PotsResponseDTO;
 import fun.trackmoney.entity.PotsEntity;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Mapper(componentModel = "spring")
-public interface PotsMapper {
+@Component
+public class PotsMapper {
 
-  List<PotsResponseDTO> listToResponse(List<PotsEntity> entityList);
+  public List<PotsResponseDTO> listToResponse(List<PotsEntity> entityList) {
+    if (entityList == null) {
+      return null;
+    }
+    return entityList.stream()
+        .map(this::toResponse)
+        .toList();
+  }
 
-  @Mapping(target = "color", source = "color.hex")
-  PotsResponseDTO toResponse(PotsEntity entity);
+  public PotsResponseDTO toResponse(PotsEntity entity) {
+    if (entity == null) {
+      return null;
+    }
+    return new PotsResponseDTO(
+        entity.getPotId(),
+        entity.getName(),
+        entity.getTargetAmount(),
+        entity.getCurrentAmount(),
+        entity.getColor() != null ? entity.getColor().getHex() : null
+    );
+  }
 
-  PotsEntity toEntity(CreatePotsDTO dto);
+  public PotsEntity toEntity(CreatePotsDTO dto) {
+    if (dto == null) {
+      return null;
+    }
+    PotsEntity entity = new PotsEntity();
+    entity.setName(dto.name());
+    entity.setTargetAmount(dto.targetAmount());
+    entity.setColor(dto.color());
+    return entity;
+  }
 }

--- a/src/main/java/fun/trackmoney/mapper/RecurringMapper.java
+++ b/src/main/java/fun/trackmoney/mapper/RecurringMapper.java
@@ -3,16 +3,49 @@ package fun.trackmoney.mapper;
 import fun.trackmoney.dto.recurring.CreateRecurringRequest;
 import fun.trackmoney.dto.recurring.RecurringResponse;
 import fun.trackmoney.entity.RecurringEntity;
-import org.mapstruct.Mapper;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Mapper(componentModel = "spring")
-public interface RecurringMapper {
+@Component
+public class RecurringMapper {
 
-  RecurringEntity toEntity(CreateRecurringRequest request);
+  public RecurringEntity toEntity(CreateRecurringRequest request) {
+    if (request == null) {
+      return null;
+    }
+    RecurringEntity entity = new RecurringEntity();
+    entity.setFrequency(request.frequency());
+    entity.setTransactionType(request.transactionType());
+    entity.setAmount(request.amount());
+    entity.setDescription(request.description());
+    entity.setTransactionName(request.transactionName());
+    return entity;
+  }
 
-  RecurringResponse toResponse(RecurringEntity save);
+  public RecurringResponse toResponse(RecurringEntity save) {
+    if (save == null) {
+      return null;
+    }
+    return new RecurringResponse(
+        save.getId(),
+        save.getFrequency(),
+        save.getCategory(),
+        save.getTransactionType(),
+        save.getNextDate(),
+        save.getLastDate(),
+        save.getAmount(),
+        save.getDescription(),
+        save.getTransactionName()
+    );
+  }
 
-  List<RecurringResponse> toResponse(List<RecurringEntity> save);
+  public List<RecurringResponse> toResponse(List<RecurringEntity> save) {
+    if (save == null) {
+      return null;
+    }
+    return save.stream()
+        .map(this::toResponse)
+        .toList();
+  }
 }

--- a/src/main/java/fun/trackmoney/mapper/TransactionMapper.java
+++ b/src/main/java/fun/trackmoney/mapper/TransactionMapper.java
@@ -3,16 +3,54 @@ package fun.trackmoney.mapper;
 import fun.trackmoney.dto.transaction.CreateTransactionDTO;
 import fun.trackmoney.dto.transaction.TransactionResponseDTO;
 import fun.trackmoney.entity.TransactionEntity;
-import org.mapstruct.Mapper;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Mapper(componentModel = "spring")
-public interface TransactionMapper {
+@Component
+public class TransactionMapper {
 
-  TransactionEntity createTransactionToEntity(CreateTransactionDTO dto);
+  private final AccountMapper accountMapper;
 
-  TransactionResponseDTO toResponseDTO(TransactionEntity save);
+  public TransactionMapper(AccountMapper accountMapper) {
+    this.accountMapper = accountMapper;
+  }
 
-  List<TransactionResponseDTO> toResponseDTOList(List<TransactionEntity> all);
+  public TransactionEntity createTransactionToEntity(CreateTransactionDTO dto) {
+    if (dto == null) {
+      return null;
+    }
+    TransactionEntity entity = new TransactionEntity();
+    entity.setTransactionType(dto.transactionType());
+    entity.setAmount(dto.amount());
+    entity.setDescription(dto.description());
+    entity.setTransactionDate(dto.transactionDate());
+    entity.setTransactionName(dto.transactionName());
+    return entity;
+  }
+
+  public TransactionResponseDTO toResponseDTO(TransactionEntity save) {
+    if (save == null) {
+      return null;
+    }
+    return new TransactionResponseDTO(
+        save.getTransactionId(),
+        save.getTransactionName(),
+        save.getDescription(),
+        save.getAmount(),
+        accountMapper.accountEntityToAccountResponse(save.getAccount()),
+        save.getTransactionType(),
+        save.getCategory(),
+        save.getTransactionDate()
+    );
+  }
+
+  public List<TransactionResponseDTO> toResponseDTOList(List<TransactionEntity> all) {
+    if (all == null) {
+      return null;
+    }
+    return all.stream()
+        .map(this::toResponseDTO)
+        .toList();
+  }
 }

--- a/src/main/java/fun/trackmoney/mapper/TransactionSimpleMapper.java
+++ b/src/main/java/fun/trackmoney/mapper/TransactionSimpleMapper.java
@@ -2,14 +2,31 @@ package fun.trackmoney.mapper;
 
 import fun.trackmoney.dto.transaction.TransactionSimpleDTO;
 import fun.trackmoney.entity.TransactionEntity;
-import org.mapstruct.Mapper;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Mapper(componentModel = "spring")
-public interface TransactionSimpleMapper {
+@Component
+public class TransactionSimpleMapper {
 
-  TransactionSimpleDTO entityToSimpleDTO(TransactionEntity entity);
+  public TransactionSimpleDTO entityToSimpleDTO(TransactionEntity entity) {
+    if (entity == null) {
+      return null;
+    }
+    return new TransactionSimpleDTO(
+        entity.getTransactionId(),
+        entity.getTransactionName(),
+        entity.getAmount(),
+        entity.getTransactionDate()
+    );
+  }
 
-  List<TransactionSimpleDTO> entityListToSimpleDTOList(List<TransactionEntity> entityList);
+  public List<TransactionSimpleDTO> entityListToSimpleDTOList(List<TransactionEntity> entityList) {
+    if (entityList == null) {
+      return null;
+    }
+    return entityList.stream()
+        .map(this::entityToSimpleDTO)
+        .toList();
+  }
 }

--- a/src/main/java/fun/trackmoney/mapper/UserMapper.java
+++ b/src/main/java/fun/trackmoney/mapper/UserMapper.java
@@ -3,11 +3,41 @@ package fun.trackmoney.mapper;
 import fun.trackmoney.dto.user.UserRequestDTO;
 import fun.trackmoney.dto.user.UserResponseDTO;
 import fun.trackmoney.entity.UserEntity;
-import org.mapstruct.Mapper;
+import org.springframework.stereotype.Component;
 
-@Mapper(componentModel = "spring")
-public interface UserMapper {
-  UserResponseDTO userEntityToUserResponseDto(UserEntity user);
+@Component
+public class UserMapper {
 
-  UserEntity userRequestDTOToEntity(UserRequestDTO dto);
+  public UserResponseDTO userEntityToUserResponseDto(UserEntity user) {
+    if (user == null) {
+      return null;
+    }
+    return new UserResponseDTO(
+        user.getUserId(),
+        user.getName(),
+        user.getEmail()
+    );
+  }
+
+  public UserEntity userRequestDTOToEntity(UserRequestDTO dto) {
+    if (dto == null) {
+      return null;
+    }
+    UserEntity entity = new UserEntity();
+    entity.setName(dto.name());
+    entity.setEmail(dto.email());
+    entity.setPassword(dto.password());
+    return entity;
+  }
+
+  public UserEntity userResponseDtoToEntity(UserResponseDTO dto) {
+    if (dto == null) {
+      return null;
+    }
+    UserEntity entity = new UserEntity();
+    entity.setUserId(dto.userId());
+    entity.setName(dto.name());
+    entity.setEmail(dto.email());
+    return entity;
+  }
 }

--- a/src/test/java/fun/trackmoney/mapper/AccountMapperTest.java
+++ b/src/test/java/fun/trackmoney/mapper/AccountMapperTest.java
@@ -1,0 +1,132 @@
+package fun.trackmoney.mapper;
+
+import fun.trackmoney.dto.account.AccountRequestDTO;
+import fun.trackmoney.dto.account.AccountResponseDTO;
+import fun.trackmoney.dto.account.AccountUpdateRequestDTO;
+import fun.trackmoney.entity.AccountEntity;
+import fun.trackmoney.testutils.AccountEntityFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AccountMapperTest {
+
+  private AccountMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new AccountMapper(new UserMapper());
+  }
+
+  @Test
+  void accountRequestToAccountEntity_shouldMapNameAndBalance() {
+    AccountRequestDTO dto = new AccountRequestDTO(UUID.randomUUID(), "Conta", BigDecimal.valueOf(500));
+
+    AccountEntity entity = mapper.accountRequestToAccountEntity(dto);
+
+    assertNotNull(entity);
+    assertEquals("Conta", entity.getName());
+    assertEquals(BigDecimal.valueOf(500), entity.getBalance());
+  }
+
+  @Test
+  void accountRequestToAccountEntity_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.accountRequestToAccountEntity(null));
+  }
+
+  @Test
+  void accountUpdateRequestToAccountEntity_shouldMapNameOnly() {
+    AccountUpdateRequestDTO dto = new AccountUpdateRequestDTO("Novo Nome");
+
+    AccountEntity entity = mapper.accountUpdateRequestToAccountEntity(dto);
+
+    assertNotNull(entity);
+    assertEquals("Novo Nome", entity.getName());
+  }
+
+  @Test
+  void accountUpdateRequestToAccountEntity_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.accountUpdateRequestToAccountEntity(null));
+  }
+
+  @Test
+  void accountEntityToAccountResponse_shouldMapAllFieldsIncludingUser() {
+    AccountEntity entity = AccountEntityFactory.defaultAccount();
+
+    AccountResponseDTO dto = mapper.accountEntityToAccountResponse(entity);
+
+    assertNotNull(dto);
+    assertEquals(entity.getAccountId(), dto.accountId());
+    assertEquals(entity.getName(), dto.name());
+    assertEquals(entity.getBalance(), dto.balance());
+    assertNotNull(dto.user());
+    assertEquals(entity.getUser().getUserId(), dto.user().userId());
+    assertEquals(entity.getUser().getName(), dto.user().name());
+    assertEquals(entity.getUser().getEmail(), dto.user().email());
+  }
+
+  @Test
+  void accountEntityToAccountResponse_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.accountEntityToAccountResponse(null));
+  }
+
+  @Test
+  void accountEntityListToAccountResponseList_shouldMapList() {
+    List<AccountEntity> entities = List.of(
+        AccountEntityFactory.defaultAccount(),
+        AccountEntityFactory.savingsAccount()
+    );
+
+    List<AccountResponseDTO> dtos = mapper.accountEntityListToAccountResponseList(entities);
+
+    assertNotNull(dtos);
+    assertEquals(2, dtos.size());
+    assertEquals(1, dtos.get(0).accountId());
+    assertEquals(2, dtos.get(1).accountId());
+  }
+
+  @Test
+  void accountEntityListToAccountResponseList_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.accountEntityListToAccountResponseList(null));
+  }
+
+  @Test
+  void accountResponseToEntity_shouldMapAllFields() {
+    AccountEntity original = AccountEntityFactory.defaultAccount();
+    AccountResponseDTO dto = mapper.accountEntityToAccountResponse(original);
+
+    AccountEntity entity = mapper.accountResponseToEntity(dto);
+
+    assertNotNull(entity);
+    assertEquals(dto.accountId(), entity.getAccountId());
+    assertEquals(dto.name(), entity.getName());
+    assertEquals(dto.balance(), entity.getBalance());
+    assertNotNull(entity.getUser());
+    assertEquals(dto.user().userId(), entity.getUser().getUserId());
+  }
+
+  @Test
+  void accountResponseToEntity_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.accountResponseToEntity(null));
+  }
+
+  @Test
+  void toAccountRequest_shouldMapNameOnly() {
+    AccountEntity entity = AccountEntityFactory.defaultAccount();
+
+    AccountUpdateRequestDTO dto = mapper.toAccountRequest(entity);
+
+    assertNotNull(dto);
+    assertEquals(entity.getName(), dto.name());
+  }
+
+  @Test
+  void toAccountRequest_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.toAccountRequest(null));
+  }
+}

--- a/src/test/java/fun/trackmoney/mapper/BudgetHistoryMapperTest.java
+++ b/src/test/java/fun/trackmoney/mapper/BudgetHistoryMapperTest.java
@@ -1,0 +1,62 @@
+package fun.trackmoney.mapper;
+
+import fun.trackmoney.dto.budget.BudgetHistoryResponseDTO;
+import fun.trackmoney.entity.BudgetHistoryEntity;
+import fun.trackmoney.testutils.BudgetHistoryEntityFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BudgetHistoryMapperTest {
+
+  private final BudgetHistoryMapper mapper = new BudgetHistoryMapper();
+
+  @Test
+  void entityToResponseDTO_shouldMapAllFieldsExceptTransactionsAndBudgetId() {
+    BudgetHistoryEntity entity = BudgetHistoryEntityFactory.defaultBudgetHistory();
+
+    BudgetHistoryResponseDTO dto = mapper.entityToResponseDTO(entity);
+
+    assertNotNull(dto);
+    assertEquals(entity.getHistoryId(), dto.historyId());
+    assertNull(dto.budgetId());
+    assertEquals(entity.getCategory(), dto.category());
+    assertEquals(entity.getReferenceMonth(), dto.referenceMonth());
+    assertEquals(entity.getReferenceYear(), dto.referenceYear());
+    assertEquals(entity.getPercent(), dto.percent());
+    assertEquals(entity.getTargetAmount(), dto.targetAmount());
+    assertEquals(entity.getSpentAmount(), dto.spentAmount());
+    assertEquals(entity.getRemainingAmount(), dto.remainingAmount());
+    assertEquals(entity.getTotalIncome(), dto.totalIncome());
+    assertNull(dto.transactions());
+    assertEquals(entity.getStatus(), dto.status());
+    assertEquals(entity.getCreatedAt(), dto.createdAt());
+  }
+
+  @Test
+  void entityToResponseDTO_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.entityToResponseDTO(null));
+  }
+
+  @Test
+  void entityListToResponseList_shouldMapList() {
+    List<BudgetHistoryEntity> entities = List.of(
+        BudgetHistoryEntityFactory.defaultBudgetHistory(),
+        BudgetHistoryEntityFactory.exceededBudgetHistory()
+    );
+
+    List<BudgetHistoryResponseDTO> dtos = mapper.entityListToResponseList(entities);
+
+    assertNotNull(dtos);
+    assertEquals(2, dtos.size());
+    assertEquals(1, dtos.get(0).historyId());
+    assertEquals(2, dtos.get(1).historyId());
+  }
+
+  @Test
+  void entityListToResponseList_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.entityListToResponseList(null));
+  }
+}

--- a/src/test/java/fun/trackmoney/mapper/BudgetMapperTest.java
+++ b/src/test/java/fun/trackmoney/mapper/BudgetMapperTest.java
@@ -1,0 +1,80 @@
+package fun.trackmoney.mapper;
+
+import fun.trackmoney.dto.budget.BudgetCreateDTO;
+import fun.trackmoney.dto.budget.BudgetResponseDTO;
+import fun.trackmoney.entity.BudgetsEntity;
+import fun.trackmoney.testutils.BudgetCreateDTOFactory;
+import fun.trackmoney.testutils.BudgetsEntityFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BudgetMapperTest {
+
+  private BudgetMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new BudgetMapper(new AccountMapper(new UserMapper()));
+  }
+
+  @Test
+  void createDtoTOEntity_shouldMapPercentOnly() {
+    BudgetCreateDTO dto = BudgetCreateDTOFactory.defaultDTO();
+
+    BudgetsEntity entity = mapper.createDtoTOEntity(dto);
+
+    assertNotNull(entity);
+    assertEquals(dto.percent(), entity.getPercent());
+  }
+
+  @Test
+  void createDtoTOEntity_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.createDtoTOEntity(null));
+  }
+
+  @Test
+  void entityToResponseDTO_shouldMapAllFieldsAndLeaveComputedFieldsNull() {
+    BudgetsEntity entity = BudgetsEntityFactory.defaultBudget();
+
+    BudgetResponseDTO dto = mapper.entityToResponseDTO(entity);
+
+    assertNotNull(dto);
+    assertEquals(entity.getBudgetId(), dto.budgetId());
+    assertEquals(entity.getCategory(), dto.category());
+    assertEquals(entity.getPercent(), dto.percent());
+    assertNotNull(dto.account());
+    assertEquals(entity.getAccount().getAccountId(), dto.account().accountId());
+    assertNull(dto.targetAmount());
+    assertNull(dto.currentAmount());
+    assertNull(dto.lastTransactions());
+  }
+
+  @Test
+  void entityToResponseDTO_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.entityToResponseDTO(null));
+  }
+
+  @Test
+  void entityListToResponseList_shouldMapList() {
+    List<BudgetsEntity> entities = List.of(
+        BudgetsEntityFactory.defaultBudget(),
+        BudgetsEntityFactory.secondaryBudget()
+    );
+
+    List<BudgetResponseDTO> dtos = mapper.entityListToResponseList(entities);
+
+    assertNotNull(dtos);
+    assertEquals(2, dtos.size());
+    assertEquals(1, dtos.get(0).budgetId());
+    assertEquals(2, dtos.get(1).budgetId());
+  }
+
+  @Test
+  void entityListToResponseList_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.entityListToResponseList(null));
+  }
+}

--- a/src/test/java/fun/trackmoney/mapper/CategoryMapperTest.java
+++ b/src/test/java/fun/trackmoney/mapper/CategoryMapperTest.java
@@ -1,0 +1,60 @@
+package fun.trackmoney.mapper;
+
+import fun.trackmoney.dto.category.CategoryResponseDTO;
+import fun.trackmoney.entity.CategoryEntity;
+import fun.trackmoney.testutils.CategoryEntityFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CategoryMapperTest {
+
+  private final CategoryMapper mapper = new CategoryMapper();
+
+  @Test
+  void categoryEntityToCategoryResponse_shouldMapAllFields() {
+    CategoryEntity entity = CategoryEntityFactory.defaultCategory();
+
+    CategoryResponseDTO dto = mapper.categoryEntityToCategoryResponse(entity);
+
+    assertNotNull(dto);
+    assertEquals(entity.getCategoryId(), dto.categoryId());
+    assertEquals(entity.getName(), dto.name());
+    assertEquals(entity.getColor(), dto.color());
+  }
+
+  @Test
+  void categoryEntityToCategoryResponse_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.categoryEntityToCategoryResponse(null));
+  }
+
+  @Test
+  void categoryEntityListToResponseList_shouldMapList() {
+    List<CategoryEntity> entities = List.of(
+        CategoryEntityFactory.defaultCategory(),
+        CategoryEntityFactory.transportCategory()
+    );
+
+    List<CategoryResponseDTO> dtos = mapper.categoryEntityListToResponseList(entities);
+
+    assertNotNull(dtos);
+    assertEquals(2, dtos.size());
+    assertEquals(1, dtos.get(0).categoryId());
+    assertEquals(2, dtos.get(1).categoryId());
+  }
+
+  @Test
+  void categoryEntityListToResponseList_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.categoryEntityListToResponseList(null));
+  }
+
+  @Test
+  void categoryEntityListToResponseList_shouldMapEmptyList() {
+    List<CategoryResponseDTO> dtos = mapper.categoryEntityListToResponseList(List.of());
+
+    assertNotNull(dtos);
+    assertEquals(0, dtos.size());
+  }
+}

--- a/src/test/java/fun/trackmoney/mapper/PotsMapperTest.java
+++ b/src/test/java/fun/trackmoney/mapper/PotsMapperTest.java
@@ -1,0 +1,90 @@
+package fun.trackmoney.mapper;
+
+import fun.trackmoney.dto.pots.CreatePotsDTO;
+import fun.trackmoney.dto.pots.PotsResponseDTO;
+import fun.trackmoney.entity.PotsEntity;
+import fun.trackmoney.enums.ColorPick;
+import fun.trackmoney.testutils.CreatePotsDTOFactory;
+import fun.trackmoney.testutils.PotsEntityFactory;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PotsMapperTest {
+
+  private final PotsMapper mapper = new PotsMapper();
+
+  @Test
+  void toResponse_shouldMapAllFieldsAndExtractColorHex() {
+    PotsEntity entity = PotsEntityFactory.defaultPot();
+
+    PotsResponseDTO dto = mapper.toResponse(entity);
+
+    assertNotNull(dto);
+    assertEquals(entity.getPotId(), dto.potId());
+    assertEquals(entity.getName(), dto.name());
+    assertEquals(entity.getTargetAmount(), dto.targetAmount());
+    assertEquals(entity.getCurrentAmount(), dto.currentAmount());
+    assertEquals(ColorPick.DARK_BLUE.getHex(), dto.color());
+  }
+
+  @Test
+  void toResponse_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.toResponse(null));
+  }
+
+  @Test
+  void toResponse_shouldHandleNullColor() {
+    PotsEntity entity = new PotsEntity();
+    entity.setPotId(1L);
+    entity.setName("Test");
+    entity.setTargetAmount(BigDecimal.TEN);
+    entity.setCurrentAmount(BigDecimal.ZERO);
+    entity.setColor(null);
+
+    PotsResponseDTO dto = mapper.toResponse(entity);
+
+    assertNotNull(dto);
+    assertNull(dto.color());
+  }
+
+  @Test
+  void toEntity_shouldMapAllFields() {
+    CreatePotsDTO dto = CreatePotsDTOFactory.defaultCreatePot();
+
+    PotsEntity entity = mapper.toEntity(dto);
+
+    assertNotNull(entity);
+    assertEquals(dto.name(), entity.getName());
+    assertEquals(dto.targetAmount(), entity.getTargetAmount());
+    assertEquals(dto.color(), entity.getColor());
+  }
+
+  @Test
+  void toEntity_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.toEntity(null));
+  }
+
+  @Test
+  void listToResponse_shouldMapList() {
+    List<PotsEntity> entities = List.of(
+        PotsEntityFactory.defaultPot(),
+        PotsEntityFactory.vacationPot()
+    );
+
+    List<PotsResponseDTO> dtos = mapper.listToResponse(entities);
+
+    assertNotNull(dtos);
+    assertEquals(2, dtos.size());
+    assertEquals(1L, dtos.get(0).potId());
+    assertEquals(2L, dtos.get(1).potId());
+  }
+
+  @Test
+  void listToResponse_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.listToResponse(null));
+  }
+}

--- a/src/test/java/fun/trackmoney/mapper/RecurringMapperTest.java
+++ b/src/test/java/fun/trackmoney/mapper/RecurringMapperTest.java
@@ -1,0 +1,75 @@
+package fun.trackmoney.mapper;
+
+import fun.trackmoney.dto.recurring.CreateRecurringRequest;
+import fun.trackmoney.dto.recurring.RecurringResponse;
+import fun.trackmoney.entity.RecurringEntity;
+import fun.trackmoney.testutils.CreateRecurringRequestFactory;
+import fun.trackmoney.testutils.RecurringEntityFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RecurringMapperTest {
+
+  private final RecurringMapper mapper = new RecurringMapper();
+
+  @Test
+  void toEntity_shouldMapAllFields() {
+    CreateRecurringRequest request = CreateRecurringRequestFactory.defaultRequest();
+
+    RecurringEntity entity = mapper.toEntity(request);
+
+    assertNotNull(entity);
+    assertEquals(request.frequency(), entity.getFrequency());
+    assertEquals(request.transactionType(), entity.getTransactionType());
+    assertEquals(request.amount(), entity.getAmount());
+    assertEquals(request.description(), entity.getDescription());
+    assertEquals(request.transactionName(), entity.getTransactionName());
+  }
+
+  @Test
+  void toEntity_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.toEntity(null));
+  }
+
+  @Test
+  void toResponse_shouldMapAllFields() {
+    RecurringEntity entity = RecurringEntityFactory.defaultEntity();
+
+    RecurringResponse response = mapper.toResponse(entity);
+
+    assertNotNull(response);
+    assertEquals(entity.getId(), response.id());
+    assertEquals(entity.getFrequency(), response.frequency());
+    assertEquals(entity.getCategory(), response.category());
+    assertEquals(entity.getTransactionType(), response.transactionType());
+    assertEquals(entity.getNextDate(), response.nextDate());
+    assertEquals(entity.getLastDate(), response.lastDate());
+    assertEquals(entity.getAmount(), response.amount());
+    assertEquals(entity.getDescription(), response.description());
+    assertEquals(entity.getTransactionName(), response.transactionName());
+  }
+
+  @Test
+  void toResponse_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.toResponse((RecurringEntity) null));
+  }
+
+  @Test
+  void toResponseList_shouldMapList() {
+    List<RecurringEntity> entities = List.of(RecurringEntityFactory.defaultEntity());
+
+    List<RecurringResponse> responses = mapper.toResponse(entities);
+
+    assertNotNull(responses);
+    assertEquals(1, responses.size());
+    assertEquals(1L, responses.get(0).id());
+  }
+
+  @Test
+  void toResponseList_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.toResponse((List<RecurringEntity>) null));
+  }
+}

--- a/src/test/java/fun/trackmoney/mapper/TransactionMapperTest.java
+++ b/src/test/java/fun/trackmoney/mapper/TransactionMapperTest.java
@@ -1,0 +1,85 @@
+package fun.trackmoney.mapper;
+
+import fun.trackmoney.dto.transaction.CreateTransactionDTO;
+import fun.trackmoney.dto.transaction.TransactionResponseDTO;
+import fun.trackmoney.entity.TransactionEntity;
+import fun.trackmoney.testutils.CreateTransactionDTOBuilder;
+import fun.trackmoney.testutils.TransactionEntityFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TransactionMapperTest {
+
+  private TransactionMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new TransactionMapper(new AccountMapper(new UserMapper()));
+  }
+
+  @Test
+  void createTransactionToEntity_shouldMapAllFields() {
+    CreateTransactionDTO dto = CreateTransactionDTOBuilder.defaultTransaction();
+
+    TransactionEntity entity = mapper.createTransactionToEntity(dto);
+
+    assertNotNull(entity);
+    assertEquals(dto.transactionType(), entity.getTransactionType());
+    assertEquals(dto.amount(), entity.getAmount());
+    assertEquals(dto.description(), entity.getDescription());
+    assertEquals(dto.transactionDate(), entity.getTransactionDate());
+    assertEquals(dto.transactionName(), entity.getTransactionName());
+  }
+
+  @Test
+  void createTransactionToEntity_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.createTransactionToEntity(null));
+  }
+
+  @Test
+  void toResponseDTO_shouldMapAllFieldsIncludingAccount() {
+    TransactionEntity entity = TransactionEntityFactory.defaultExpenseNow();
+
+    TransactionResponseDTO dto = mapper.toResponseDTO(entity);
+
+    assertNotNull(dto);
+    assertEquals(entity.getTransactionId(), dto.transactionId());
+    assertEquals(entity.getTransactionName(), dto.transactionName());
+    assertEquals(entity.getDescription(), dto.description());
+    assertEquals(entity.getAmount(), dto.amount());
+    assertEquals(entity.getTransactionType(), dto.transactionType());
+    assertEquals(entity.getCategory(), dto.category());
+    assertEquals(entity.getTransactionDate(), dto.transactionDate());
+    assertNotNull(dto.account());
+    assertEquals(entity.getAccount().getAccountId(), dto.account().accountId());
+  }
+
+  @Test
+  void toResponseDTO_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.toResponseDTO(null));
+  }
+
+  @Test
+  void toResponseDTOList_shouldMapList() {
+    List<TransactionEntity> entities = List.of(
+        TransactionEntityFactory.defaultExpenseNow(),
+        TransactionEntityFactory.defaultIncomeNow()
+    );
+
+    List<TransactionResponseDTO> dtos = mapper.toResponseDTOList(entities);
+
+    assertNotNull(dtos);
+    assertEquals(2, dtos.size());
+    assertEquals(1, dtos.get(0).transactionId());
+    assertEquals(2, dtos.get(1).transactionId());
+  }
+
+  @Test
+  void toResponseDTOList_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.toResponseDTOList(null));
+  }
+}

--- a/src/test/java/fun/trackmoney/mapper/TransactionSimpleMapperTest.java
+++ b/src/test/java/fun/trackmoney/mapper/TransactionSimpleMapperTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 class TransactionSimpleMapperTest {
 
-  private final TransactionSimpleMapper mapper = new TransactionSimpleMapperImpl();
+  private final TransactionSimpleMapper mapper = new TransactionSimpleMapper();
 
   @Test
   void entityToSimpleDTO_shouldMapAllFields() {

--- a/src/test/java/fun/trackmoney/mapper/UserMapperTest.java
+++ b/src/test/java/fun/trackmoney/mapper/UserMapperTest.java
@@ -1,0 +1,68 @@
+package fun.trackmoney.mapper;
+
+import fun.trackmoney.dto.user.UserRequestDTO;
+import fun.trackmoney.dto.user.UserResponseDTO;
+import fun.trackmoney.entity.UserEntity;
+import fun.trackmoney.testutils.UserEntityFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserMapperTest {
+
+  private final UserMapper mapper = new UserMapper();
+
+  @Test
+  void userEntityToUserResponseDto_shouldMapAllFields() {
+    UserEntity entity = UserEntityFactory.defaultUser();
+
+    UserResponseDTO dto = mapper.userEntityToUserResponseDto(entity);
+
+    assertNotNull(dto);
+    assertEquals(entity.getUserId(), dto.userId());
+    assertEquals(entity.getName(), dto.name());
+    assertEquals(entity.getEmail(), dto.email());
+  }
+
+  @Test
+  void userEntityToUserResponseDto_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.userEntityToUserResponseDto(null));
+  }
+
+  @Test
+  void userRequestDTOToEntity_shouldMapAllFields() {
+    UserRequestDTO dto = new UserRequestDTO("John", "john@email.com", "pass123");
+
+    UserEntity entity = mapper.userRequestDTOToEntity(dto);
+
+    assertNotNull(entity);
+    assertEquals("John", entity.getName());
+    assertEquals("john@email.com", entity.getEmail());
+    assertEquals("pass123", entity.getPassword());
+  }
+
+  @Test
+  void userRequestDTOToEntity_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.userRequestDTOToEntity(null));
+  }
+
+  @Test
+  void userResponseDtoToEntity_shouldMapAllFields() {
+    UUID userId = UUID.randomUUID();
+    UserResponseDTO dto = new UserResponseDTO(userId, "John", "john@email.com");
+
+    UserEntity entity = mapper.userResponseDtoToEntity(dto);
+
+    assertNotNull(entity);
+    assertEquals(userId, entity.getUserId());
+    assertEquals("John", entity.getName());
+    assertEquals("john@email.com", entity.getEmail());
+  }
+
+  @Test
+  void userResponseDtoToEntity_shouldReturnNullWhenInputIsNull() {
+    assertNull(mapper.userResponseDtoToEntity(null));
+  }
+}

--- a/src/test/java/fun/trackmoney/service/CategoryServiceTest.java
+++ b/src/test/java/fun/trackmoney/service/CategoryServiceTest.java
@@ -6,7 +6,7 @@ import fun.trackmoney.dto.category.CategoryResponseDTO;
 import fun.trackmoney.entity.CategoryEntity;
 import fun.trackmoney.exception.CategoryNotFoundException;
 import fun.trackmoney.mapper.CategoryMapper;
-import fun.trackmoney.mapper.CategoryMapperImpl;
+
 import fun.trackmoney.repository.CategoryRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,7 +29,7 @@ class CategoryServiceTest {
   private CategoryRepository categoryRepository;
 
   @Spy
-  private CategoryMapper categoryMapper = new CategoryMapperImpl();
+  private CategoryMapper categoryMapper = new CategoryMapper();
 
   @InjectMocks
   private CategoryService categoryService;


### PR DESCRIPTION
## Summary
- Convert all 9 mapper interfaces from MapStruct to hand-written @Component classes
- Implement DI between mappers for shared conversions (AccountMapper → UserMapper, etc.)
- Remove MapStruct dependency and annotation processor from pom.xml
- Add unit tests for all mappers (57 tests total)

## Changes
- Mappers now use constructor injection and explicit field mapping
- Null safety handled in all mapper methods
- Custom mappings preserved (PotsMapper.color.hex, BudgetHistoryMapper.transactions ignored)